### PR TITLE
fix: startup crash, window controls, CI Linux deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
         with:
           components: clippy
 
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            pkg-config
+
       - name: Cache Cargo registry & build
         uses: actions/cache@v4
         with:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,14 @@ fn focus_window(pid: u32) {
     focus::focus_window_by_pid(pid);
 }
 
+/// Hides the dashboard window (minimize to tray).
+#[tauri::command]
+fn hide_window(app: AppHandle) {
+    if let Some(win) = app.get_webview_window("dashboard") {
+        let _ = win.hide();
+    }
+}
+
 /// Quits the application entirely.
 #[tauri::command]
 fn quit_app(app: AppHandle) {
@@ -176,6 +184,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_sessions,
             focus_window,
+            hide_window,
             quit_app,
             open_settings,
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,12 @@ fn focus_window(pid: u32) {
     focus::focus_window_by_pid(pid);
 }
 
+/// Quits the application entirely.
+#[tauri::command]
+fn quit_app(app: AppHandle) {
+    app.exit(0);
+}
+
 /// Placeholder for the settings window (Phase 2).
 #[tauri::command]
 async fn open_settings(app: AppHandle) {
@@ -170,6 +176,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_sessions,
             focus_window,
+            quit_app,
             open_settings,
         ])
         .run(tauri::generate_context!())

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,11 +169,11 @@ function render(): void {
 // ─── Event listeners ───────────────────────────────────────────────────────────
 
 btnMinimize.addEventListener("click", () => {
-  getCurrentWindow().minimize().catch(console.error);
+  getCurrentWindow().hide().catch(console.error);
 });
 
 btnClose.addEventListener("click", () => {
-  getCurrentWindow().hide().catch(console.error);
+  invoke("quit_app").catch(console.error);
 });
 
 btnSettings.addEventListener("click", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,7 @@ function render(): void {
 // ─── Event listeners ───────────────────────────────────────────────────────────
 
 btnMinimize.addEventListener("click", () => {
-  getCurrentWindow().hide().catch(console.error);
+  invoke("hide_window").catch(console.error);
 });
 
 btnClose.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

- Fix startup crash (`tokio::spawn` → `tauri::async_runtime::spawn`, no Tokio reactor in Tauri setup)
- Add minimize button (hides to tray via `hide_window` Rust command)
- X button now quits the app via `quit_app` Rust command
- CI: install GTK/WebKit Linux system deps before cargo steps
- Bundle NSIS only (was `all` → duplicate desktop shortcuts)

## Test plan

- [ ] App starts without crash, tray icon visible
- [ ] `—` button hides window, tray icon click restores it
- [ ] `X` button quits the app entirely
- [ ] CI passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correction du comportement au démarrage de l’application, mise à jour des actions de contrôle de la fenêtre et ajustement des dépendances CI pour les builds Linux.

Nouvelles fonctionnalités :
- Ajouter une commande de réduction dans la zone de notification (hide-to-tray) et la relier au bouton de minimisation.
- Ajouter une commande de quittage explicite et la relier au bouton de fermeture de la fenêtre.

Corrections de bugs :
- Résoudre les problèmes de démarrage en utilisant les commandes d’application natives de Tauri pour le contrôle de la fenêtre au lieu des opérations directes sur la fenêtre.

CI :
- Installer les dépendances système GTK/WebKit et associées nécessaires sur les runners CI Linux pour prendre en charge les builds Tauri.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix app startup behavior, update window control actions, and adjust CI dependencies for Linux builds.

New Features:
- Add a hide-to-tray window command and wire it to the minimize button.
- Add an explicit quit command and wire it to the window close button.

Bug Fixes:
- Resolve startup issues by using Tauri-native app commands for window control instead of direct window operations.

CI:
- Install required GTK/WebKit and related system dependencies on Linux CI runners to support Tauri builds.

</details>