### PR TITLE
feat: auto-updater (tauri-plugin-updater + GitHub Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "SynapseHub ${{ github.ref_name }}"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri            = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-notification = "2"
+tauri-plugin-updater      = "2"
+tauri-plugin-process      = "2"
 serde            = { version = "1", features = ["derive"] }
 serde_json       = "1"
 tokio            = { version = "1", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -149,6 +149,8 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             // Prevent the dashboard from appearing in the taskbar
             #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,5 +43,13 @@
       "icons/icon.ico"
     ],
     "resources": ["icons/tray.png"]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "PUBKEY_PLACEHOLDER",
+      "endpoints": [
+        "https://github.com/thierryvm/SynapseHub/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "PUBKEY_PLACEHOLDER",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJENUFBOUUxNzNBOEEzMTgKUldRWW82aHo0YWxhdmEwb2F1eTVZVVZNc3Q1SWRuczhRZzdMbjk1d0h5bDIwUTd5d2ZwaGQzeCsK",
       "endpoints": [
         "https://github.com/thierryvm/SynapseHub/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary

- Add `tauri-plugin-updater` + `tauri-plugin-process` plugins
- Configure updater endpoint → GitHub Releases `latest.json`
- Public key embedded in `tauri.conf.json`
- Private key stored as `TAURI_SIGNING_PRIVATE_KEY` GitHub Secret
- Release workflow: builds on Windows, signs installer, publishes GitHub Release with `latest.json` on `v*` tag push

## After merge

Tag `v0.1.0` to trigger the first automated release:
\`\`\`bash
git tag v0.1.0 && git push origin v0.1.0
\`\`\`

## Security

- Private key never appears in code or logs
- Empty password (key protected only by the secret itself)
- Residual risk: if `TAURI_SIGNING_PRIVATE_KEY` secret leaks, a malicious update could be pushed — rotate key immediately if compromised

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Intégrer la fonctionnalité de mise à jour automatique de Tauri, basée sur GitHub Releases, et la connecter à l’application de bureau ainsi qu’au workflow de release.

Nouvelles fonctionnalités :
- Ajouter les plugins `updater` et `process` de Tauri pour activer les mises à jour automatiques in-app à partir de GitHub Releases.

Build :
- Injecter la clé privée de signature de code Tauri et le mot de passe depuis GitHub Secrets dans le workflow de release pour produire des builds signées.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Tauri's auto-update capability backed by GitHub Releases and wire it into the desktop app and release workflow.

New Features:
- Add Tauri updater and process plugins to enable in-app auto-updates from GitHub Releases.

Build:
- Inject Tauri code-signing private key and password from GitHub Secrets into the release workflow for signed builds.

</details>