### PR TITLE
[codex] Secure local hook handling and reduce secret exposure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ Out of scope:
 
 - The local HTTP hook server binds to `127.0.0.1` only and uses a randomly generated token stored locally.
 - No credentials or secrets are ever transmitted to remote servers.
-- The token file (`config/hook_token`) is excluded from version control via `.gitignore`.
+- Hook secrets are stored in the operating system config directory (`%APPDATA%\synapsehub\` on Windows, `~/.config/synapsehub/` on macOS/Linux), not inside the repository.
+- Hook secrets must never be logged, copied into issue reports, or committed to version control.
 
 Thank you for helping keep SynapseHub secure.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,7 +56,10 @@ struct AppConfig {
 async fn get_config() -> AppConfig {
     let config_dir = dirs::config_dir().unwrap_or_default().join("synapsehub");
     
-    let token = std::fs::read_to_string(config_dir.join("hook_token")).ok();
+    let token = std::fs::read_to_string(config_dir.join("hook_token"))
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
     let port_str = std::fs::read_to_string(config_dir.join("hook_port")).ok();
     let port = port_str.and_then(|s| s.trim().parse::<u16>().ok());
 
@@ -155,8 +158,7 @@ pub fn run() {
             let handle = app.handle().clone();
             let secret = load_or_create_secret();
 
-            log::info!("Hook token loaded — configure Claude Code hooks with this token.");
-            log::info!("Hook token: {secret}");
+            log::info!("Hook token loaded — configure Claude Code hooks from the settings panel.");
 
             // Start the background watcher and hook server
             tauri::async_runtime::spawn(watcher::start_watcher(state.clone(), handle.clone()));

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,9 +182,8 @@ btnClose.addEventListener("click", () => {
 });
 
 btnSettings.addEventListener("click", async () => {
-  console.log("BOUTON CLIQUE !");
   try {
-    const config: any = await invoke("get_config");
+    const config = await invoke<{ port?: number; token?: string }>("get_config");
     const port = config.port || "PORT_INTROUVABLE";
     const token = config.token || "<TOKEN_INTROUVABLE>";
     
@@ -201,7 +200,8 @@ btnSettings.addEventListener("click", async () => {
     modalStatus.textContent = "";
     settingsModal.style.display = "flex";
   } catch (e: any) {
-    alert("CRASH JAVASCRIPT: " + e.toString());
+    modalStatus.textContent = "Impossible de charger la configuration";
+    settingsModal.style.display = "flex";
     console.error("Failed to load config:", e);
   }
 });


### PR DESCRIPTION
## What changed
- stop logging the local hook token at runtime
- trim the token before exposing it to the settings UI
- replace the raw JavaScript crash alert with a safer in-app failure message
- align the security policy with the actual OS config storage path

## Why
The local hook token is a secret. Logging it or surfacing raw internal errors increases the chance of accidental disclosure through logs, screenshots, or support reports.

## Impact
- safer local runtime behavior
- less sensitive information exposed in logs and UI
- documentation now matches the real storage model

## Validation
- `npm run build`
- `cargo check`

## Summary by Sourcery

Renforcer la gestion du jeton de hook local et de la configuration associée afin de réduire l’exposition accidentelle de secrets dans le comportement à l’exécution, l’interface utilisateur et la documentation.

Bug Fixes :
- S’assurer que le jeton de hook local lu depuis le disque est nettoyé (trim) et ignoré s’il est vide avant d’être exposé à l’application et à l’interface utilisateur.

Enhancements :
- Arrêter de journaliser la valeur du jeton de hook local au démarrage et rediriger les utilisateurs vers le panneau des paramètres pour la configuration à la place.
- Remplacer l’alerte de crash JavaScript brute lors de l’échec de chargement des paramètres par un message d’erreur in-app destiné à l’utilisateur, tout en continuant à consigner les détails dans la console.

Documentation :
- Mettre à jour la politique de sécurité pour documenter le répertoire de configuration du système d’exploitation réellement utilisé pour les secrets des hooks et préciser que ces secrets ne doivent jamais être journalisés ni ajoutés à un dépôt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten handling of the local hook token and related configuration to reduce accidental secret exposure in runtime behavior, UI, and documentation.

Bug Fixes:
- Ensure the local hook token read from disk is trimmed and ignored if empty before being exposed to the application and UI.

Enhancements:
- Stop logging the local hook token value at startup and direct users to the settings panel for configuration instead.
- Replace the raw JavaScript crash alert on settings load failure with a user-facing in-app error message while still logging details to the console.

Documentation:
- Update the security policy to document the actual OS configuration directory used for hook secrets and to clarify that these secrets must never be logged or committed.

</details>