### PR TITLE
[codex] Restore green CI before enforcing strict main protection

### DIFF
--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -16,7 +16,7 @@
 //! ```
 //!
 //! Or, using curl directly (no helper binary needed):
-//! ```
+//! ```bash
 //! curl -s -X POST http://127.0.0.1:PORT/hook \
 //!   -H "Content-Type: application/json" \
 //!   -d "{\"token\":\"TOKEN\",\"project_dir\":\"$CLAUDE_PROJECT_DIR\",\"pid\":$PPID}"


### PR DESCRIPTION
## What changed
- mark the shell hook example in `src-tauri/src/hooks.rs` as a Bash snippet instead of a Rust doctest

## Why
The repository cannot safely enforce required status checks on `main` while the current CI job is red for a documentation-only doctest issue. This PR restores a trustworthy baseline first.

## Impact
- `cargo test` reflects real code health again
- `main` can be protected with required checks without locking the repo into a failing state

## Validation
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `npm run build`

## Résumé par Sourcery

Documentation :
- Marquer l’exemple de hook shell avec `curl` dans `hooks.rs` comme un bloc de code Bash afin d’éviter qu’il ne soit exécuté comme un doctest Rust.

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Documentation :
- Clarifier l’exemple `curl` pour le hook shell dans `hooks.rs` en le marquant comme du code Bash, afin d’éviter son exécution en tant que doctest Rust.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify the shell hook curl example in hooks.rs by marking it as Bash code, avoiding its execution as a Rust doctest.

</details>

</details>