### PR TITLE
[codex] Add unit tests for watcher resume transitions

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -11,6 +11,9 @@ use sysinfo::{Pid, System};
 
 use crate::types::{AgentSession, AgentStatus, AppState, LockFile, WaitingState};
 
+const RESUME_CPU_THRESHOLD: f32 = 2.0;
+const RESUME_POLLS_REQUIRED: u8 = 2;
+
 /// Returns the current time as seconds since Unix epoch.
 fn now_secs() -> u64 {
     SystemTime::now()
@@ -28,7 +31,9 @@ fn is_pid_alive(sys: &System, pid: u32) -> bool {
 /// to consider it resumed.
 fn should_resume(waiting: &WaitingState, pid: u32, cpu_usage: f32, active_polls: u8) -> bool {
     match waiting.pid {
-        Some(waiting_pid) if waiting_pid == pid => cpu_usage >= 2.0 && active_polls >= 2,
+        Some(waiting_pid) if waiting_pid == pid => {
+            cpu_usage >= RESUME_CPU_THRESHOLD && active_polls >= RESUME_POLLS_REQUIRED
+        }
         _ => false,
     }
 }
@@ -109,7 +114,7 @@ fn scan_lock_files(
                 .process(Pid::from_u32(lock.pid))
                 .map(|p| p.cpu_usage())
                 .unwrap_or(0.0);
-            let active_polls = if waiting.pid == Some(lock.pid) && cpu_usage >= 2.0 {
+            let active_polls = if waiting.pid == Some(lock.pid) && cpu_usage >= RESUME_CPU_THRESHOLD {
                 let votes = resume_votes.entry(project_path.clone()).or_insert(0);
                 *votes = votes.saturating_add(1);
                 *votes
@@ -251,7 +256,8 @@ fn scan_processes(
             .or_insert_with(now_secs);
 
         let status = if let Some(waiting) = waiting_since.get(&cwd) {
-            let active_polls = if waiting.pid == Some(pid.as_u32()) && process.cpu_usage() >= 2.0 {
+            let active_polls =
+                if waiting.pid == Some(pid.as_u32()) && process.cpu_usage() >= RESUME_CPU_THRESHOLD {
                 let votes = resume_votes.entry(cwd.clone()).or_insert(0);
                 *votes = votes.saturating_add(1);
                 *votes
@@ -378,5 +384,90 @@ pub async fn start_watcher(state: Arc<Mutex<AppState>>, app: AppHandle) {
         }
 
         tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_resume, RESUME_CPU_THRESHOLD, RESUME_POLLS_REQUIRED};
+    use crate::types::WaitingState;
+
+    fn waiting_state(pid: Option<u32>) -> WaitingState {
+        WaitingState {
+            since_secs: 1_700_000_000,
+            pid,
+        }
+    }
+
+    #[test]
+    fn should_not_resume_without_hook_pid() {
+        let waiting = waiting_state(None);
+
+        assert!(!should_resume(
+            &waiting,
+            4242,
+            RESUME_CPU_THRESHOLD + 1.0,
+            RESUME_POLLS_REQUIRED
+        ));
+    }
+
+    #[test]
+    fn should_not_resume_with_wrong_pid() {
+        let waiting = waiting_state(Some(1111));
+
+        assert!(!should_resume(
+            &waiting,
+            2222,
+            RESUME_CPU_THRESHOLD + 1.0,
+            RESUME_POLLS_REQUIRED
+        ));
+    }
+
+    #[test]
+    fn should_not_resume_with_low_cpu() {
+        let waiting = waiting_state(Some(4242));
+
+        assert!(!should_resume(
+            &waiting,
+            4242,
+            RESUME_CPU_THRESHOLD - 0.1,
+            RESUME_POLLS_REQUIRED
+        ));
+    }
+
+    #[test]
+    fn should_not_resume_after_single_active_poll() {
+        let waiting = waiting_state(Some(4242));
+
+        assert!(!should_resume(
+            &waiting,
+            4242,
+            RESUME_CPU_THRESHOLD + 1.0,
+            RESUME_POLLS_REQUIRED - 1
+        ));
+    }
+
+    #[test]
+    fn should_resume_after_two_active_polls() {
+        let waiting = waiting_state(Some(4242));
+
+        assert!(should_resume(
+            &waiting,
+            4242,
+            RESUME_CPU_THRESHOLD + 1.0,
+            RESUME_POLLS_REQUIRED
+        ));
+    }
+
+    #[test]
+    fn should_resume_after_hook_stop_when_same_pid_becomes_active_again() {
+        let waiting = waiting_state(Some(9001));
+
+        assert!(should_resume(
+            &waiting,
+            9001,
+            RESUME_CPU_THRESHOLD + 2.5,
+            RESUME_POLLS_REQUIRED
+        ));
     }
 }


### PR DESCRIPTION
## What changed
- extract the resume thresholds into named constants in `watcher.rs`
- add focused Rust unit tests around `should_resume`
- cover the main edge cases for `running -> waiting -> resumed`

## Covered cases
- missing hook PID
- wrong PID
- low CPU activity
- strong CPU activity on only one poll
- strong CPU activity on two polls
- correct resume after a `Stop` hook for the same PID

## Why
The resume logic is the most fragile part of the current watcher flow. These tests lock down behavior without spinning up the Tauri app or the background scanner.

## Validation
- `cargo test`
- `cargo clippy --all-features -- -D warnings`
- `npm run build`

## Résumé par Sourcery

Ajoute des constantes partagées pour les seuils de reprise dans le watcher et introduit des tests unitaires pour figer le comportement de reprise du watcher.

Améliorations :
- Extrait les seuils de reprise d’utilisation CPU et de nombre de sondages (poll count) dans des constantes nommées partagées, réutilisées à la fois par la logique de fichier de verrouillage (lock file) et par la logique de scan de processus.

Tests :
- Ajoute des tests unitaires ciblés pour `should_resume` couvrant les divergences de PID, la faible utilisation CPU, un nombre insuffisant de sondages actifs, et la reprise correcte après une activité suffisante.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add shared resume threshold constants to the watcher and introduce unit tests to lock down watcher resume behavior.

Enhancements:
- Extract CPU usage and poll count resume thresholds into shared named constants reused across lock file and process scanning logic.

Tests:
- Add focused unit tests for `should_resume` covering PID mismatches, low CPU usage, insufficient active polls, and correct resume after sufficient activity.

</details>

Améliorations :
- Extraire les seuils de reprise CPU et de sondage du watcher dans des constantes nommées partagées, utilisées à la fois par la logique d’analyse des fichiers de verrouillage et celle d’analyse des processus.

Tests :
- Ajouter des tests unitaires ciblés pour `should_resume` couvrant les divergences de PID, la faible utilisation CPU, un nombre de sondages insuffisant et la reprise correcte après une activité suffisante.

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Ajoute des constantes partagées pour les seuils de reprise dans le watcher et introduit des tests unitaires pour figer le comportement de reprise du watcher.

Améliorations :
- Extrait les seuils de reprise d’utilisation CPU et de nombre de sondages (poll count) dans des constantes nommées partagées, réutilisées à la fois par la logique de fichier de verrouillage (lock file) et par la logique de scan de processus.

Tests :
- Ajoute des tests unitaires ciblés pour `should_resume` couvrant les divergences de PID, la faible utilisation CPU, un nombre insuffisant de sondages actifs, et la reprise correcte après une activité suffisante.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add shared resume threshold constants to the watcher and introduce unit tests to lock down watcher resume behavior.

Enhancements:
- Extract CPU usage and poll count resume thresholds into shared named constants reused across lock file and process scanning logic.

Tests:
- Add focused unit tests for `should_resume` covering PID mismatches, low CPU usage, insufficient active polls, and correct resume after sufficient activity.

</details>

</details>