### PR TITLE
[codex] Keep concurrent agents visible per project

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -57,6 +57,11 @@ fn project_name(path: &str) -> String {
         .to_owned()
 }
 
+/// Stable deduplication key per visible agent on a project.
+fn session_identity(project_path: &str, ide_name: &str) -> String {
+    format!("{project_path}::{ide_name}")
+}
+
 /// Returns true when a path points to system-owned locations that do not
 /// represent a user project we should surface in the dashboard.
 fn is_system_path(path: &str) -> bool {
@@ -263,11 +268,13 @@ fn scan_processes(
 ) -> (Vec<AgentSession>, Vec<String>) {
     let mut sessions = vec![];
     let mut resumed_projects = vec![];
-    let mut seen_projects = std::collections::HashSet::new();
+    let mut seen_sessions = std::collections::HashSet::new();
 
-    // Preremplir avec les projets déjà trouvés par scan_lock_files
+    // Pre-fill with sessions already found via lock files so we keep one visible
+    // entry per project + agent kind, while still allowing Codex and Claude to
+    // coexist on the same repository.
     for s in existing_sessions {
-        seen_projects.insert(s.project_path.clone());
+        seen_sessions.insert(session_identity(&s.project_path, &s.ide_name));
     }
 
     for (pid, process) in sys.processes() {
@@ -290,11 +297,13 @@ fn scan_processes(
             None => continue,
         };
 
-        // Avoid duplicating sessions for the same project
-        if seen_projects.contains(&cwd) {
+        let identity = session_identity(&cwd, ide_name);
+
+        // Avoid duplicating the exact same visible agent on the same project.
+        if seen_sessions.contains(&identity) {
             continue;
         }
-        seen_projects.insert(cwd.clone());
+        seen_sessions.insert(identity);
 
         // Use a stable identifier to track uptime
         let lock_file = format!("process_{}", cwd);

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -88,6 +88,27 @@ export function summarizeSessions(sessions: AgentSession[]): SessionSummary {
     };
   }
 
+  if (activeSessions.length === 1) {
+    const session = activeSessions[0];
+    const project = session.project_name || projectNameFromPath(session.project_path);
+
+    return {
+      activeCount: 1,
+      runningCount,
+      waitingCount,
+      trackedProjects,
+      title:
+        session.status.type === "Waiting"
+          ? `${session.ide_name} attend sur ${project}`
+          : `${session.ide_name} actif sur ${project}`,
+      subtitle:
+        session.status.type === "Waiting"
+          ? "La session a besoin d'une reprise ou d'une interaction utilisateur."
+          : "Une session IA est en cours sur ce projet.",
+      footer: session.git_branch ? `Branche ${session.git_branch}` : "Projet suivi sans branche detectee",
+    };
+  }
+
   if (waitingCount > 0) {
     const noun = waitingCount > 1 ? "agents demandent" : "agent demande";
     return {


### PR DESCRIPTION
## What changed
- stop deduplicating visible sessions only by project path
- keep one visible entry per project and agent kind so Codex, Claude Code and IDE sessions can coexist
- improve the single-session dashboard summary so the active agent and project are named explicitly

## Why
- multiple AI tools can run on the same repository at the same time
- collapsing by project path hides the very information the dashboard is supposed to surface

## Validation
- npm run build
- npm test
- cargo test

## Summary by Sourcery

Suivre les sessions d’agent concurrentes par projet selon le type d’agent et améliorer les résumés du tableau de bord pour une seule session.

Nouvelles fonctionnalités :
- Représenter les sessions visibles par projet et par type d’agent au lieu de les regrouper uniquement par chemin de projet.
- Fournir un résumé de tableau de bord adapté lorsqu’il n’existe qu’une seule session active, en nommant explicitement l’agent et le projet.

Corrections de bugs :
- Empêcher que différents types d’agents sur le même projet soient dédupliqués en une seule entrée de session visible.

Améliorations :
- Utiliser une identité de session stable combinant le chemin du projet et le nom de l’IDE lors de la recherche des processus afin d’éviter les entrées dupliquées pour le même agent sur un projet.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track concurrent agent sessions per project by agent type and improve single-session dashboard summaries.

New Features:
- Represent visible sessions per project and agent kind instead of collapsing them by project path alone.
- Provide a tailored dashboard summary when exactly one active session exists, explicitly naming the agent and project.

Bug Fixes:
- Prevent different agent types on the same project from being deduplicated into a single visible session entry.

Enhancements:
- Use a stable session identity combining project path and IDE name when scanning processes to avoid duplicate entries for the same agent on a project.

</details>