### PR TITLE
[codex] Improve settings sheet responsiveness

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -616,16 +616,19 @@ body {
   display: flex;
   align-items: end;
   justify-content: center;
+  padding: 10px;
   background: rgba(2, 6, 18, 0.66);
   backdrop-filter: blur(12px);
 }
 
 .bottom-sheet {
   width: 100%;
-  max-height: 88%;
+  max-height: min(88vh, 720px);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   border-top: 1px solid var(--border-strong);
-  border-radius: 26px 26px 0 0;
+  border-radius: 26px;
   background:
     radial-gradient(circle at top right, rgba(157, 140, 255, 0.14), transparent 32%),
     var(--bg-panel-strong);
@@ -657,12 +660,25 @@ body {
 }
 
 .modal-body {
+  flex: 1;
+  min-height: 0;
   padding: 18px;
   display: flex;
   flex-direction: column;
   gap: 16px;
   overflow-y: auto;
-  min-height: 0;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
+}
+
+.modal-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.modal-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
 }
 
 .guide-grid {
@@ -716,18 +732,21 @@ body {
 
 .code-block-wrapper {
   padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .code-block-header {
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
-  margin-bottom: 10px;
   font-size: 12px;
   color: var(--text-secondary);
 }
 
 .code-block {
-  max-height: 220px;
+  max-height: clamp(180px, 26vh, 260px);
   overflow-x: auto;
   overflow-y: auto;
   padding: 14px;
@@ -808,6 +827,16 @@ body {
 }
 
 @media (max-width: 460px) {
+  .modal-overlay {
+    padding: 0;
+    align-items: end;
+  }
+
+  .bottom-sheet {
+    max-height: min(96vh, 760px);
+    border-radius: 26px 26px 0 0;
+  }
+
   .hero-panel {
     grid-template-columns: 1fr;
   }
@@ -827,6 +856,10 @@ body {
 }
 
 @media (max-height: 620px) {
+  .modal-overlay {
+    padding: 6px;
+  }
+
   #app {
     padding: 8px;
   }
@@ -862,7 +895,7 @@ body {
   }
 
   .bottom-sheet {
-    max-height: 94%;
+    max-height: calc(100vh - 12px);
   }
 
   .modal-header {
@@ -881,7 +914,7 @@ body {
   .guide-card,
   .code-block-wrapper,
   .update-card {
-    padding: 12px;
+    padding: 11px;
   }
 
   .guide-card h3,
@@ -896,8 +929,8 @@ body {
   }
 
   .code-block {
-    max-height: 150px;
-    padding: 12px;
+    max-height: clamp(120px, 22vh, 180px);
+    padding: 10px;
     font-size: 10px;
     line-height: 1.5;
   }


### PR DESCRIPTION
## What changed
- make the settings sheet a true vertical flex container
- improve scroll behavior for small window heights
- keep the configuration block and copy action reachable on narrow or short viewports
- preserve the current visual language on desktop and mobile-sized windows

## Why
The settings panel became hard to use on compact desktop windows because the lower section could be clipped, making the JSON configuration and copy button difficult to reach.

## Validation
- npm run build
- npm test

## Summary by Sourcery

Améliorer la disposition de la feuille inférieure des paramètres et le comportement de défilement pour une meilleure ergonomie sur les petits écrans ou les fenêtres de visualisation contraintes.

Améliorations :
- Transformer la feuille inférieure en conteneur flex vertical avec des hauteurs maximales contraintes en fonction de la taille de la fenêtre de visualisation.
- Ajuster le corps de la modale pour qu’il s’adapte en flex à l’intérieur de la feuille et affiner le comportement de défilement, y compris la limitation de l’overscroll et les barres de défilement personnalisées.
- Retravailler le wrapper de bloc de code et la disposition de l’en-tête afin qu’ils se replient et restent accessibles sur des fenêtres de visualisation étroites.
- Ajuster les points de rupture responsives et les espacements pour que les hauteurs de la feuille et des blocs de code s’adaptent aux fenêtres courtes et aux écrans mobiles.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the settings bottom sheet layout and scrolling behavior for better usability on small or constrained viewports.

Enhancements:
- Make the bottom sheet a vertical flex container with constrained max-heights based on viewport size.
- Adjust modal body to flex within the sheet and refine scroll behavior, including overscroll containment and custom scrollbars.
- Rework the code block wrapper and header layout to wrap and remain accessible on narrow viewports.
- Tune responsive breakpoints and paddings so the sheet and code block heights adapt to short and mobile-sized windows.

</details>