### PR TITLE
feat(ergonomics): v0.1.1 UX + vitest CI + bump release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: npm ci
         run: npm ci
 
+      - name: Frontend tests (vitest)
+        run: npm test
+
       - name: npm run build
         run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to SynapseHub will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2026-04-29
+
+### Security
+- **S1** Timing-safe token comparison via `subtle::ConstantTimeEq` ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- **S2** Token entropy fixed: `OsRng` 32 bytes → 64 hex consistent ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- **S3** `0600` perms on Unix for `hook_token` file ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- **S4** Rate limit `POST /hook` to 10 req/s via `tower_governor` ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- **S12** `cargo audit` step added in CI as hard gate ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- **S13** Frontend deps audit fix: vite 6.4.2, postcss 8.5.12 ([#12](https://github.com/thierryvm/SynapseHub/pull/12))
+- Bumped `rustls-webpki` 0.103.10 → 0.103.13 (fixes RUSTSEC-2026-0098 / 0099 / 0104)
+- Bumped `git2` 0.19 → 0.20.4 (fixes RUSTSEC-2026-0008)
+- 19 transitive advisories documented in `audit.toml` with rationale + GitHub trackers ([#13](https://github.com/thierryvm/SynapseHub/issues/13), [#14](https://github.com/thierryvm/SynapseHub/issues/14), [#15](https://github.com/thierryvm/SynapseHub/issues/15))
+
+### Tests
+- 13 new router-level tests via `EventEmitter` trait (10 → 23 on Windows / 24 on Unix)
+- Vitest now runs in CI
+
+### UX
+- Settings modal: Claude Code Terminal added to the detected agents wording
+- Settings modal: code block uses `white-space: pre-wrap` for full token visibility
+- Settings modal: explicit user-level vs project-level paths documented
+- Empty state: removed redundant `hero-orbit`, single visual focus
+- Header `agent-badge`: `-webkit-app-region: no-drag` so clicks don't trigger a window drag
+
+## [0.1.0] - 2026-03-27
+
+### Added
+- MVP: tray icon + dashboard + Claude Code Stop hook + multi-IDE detection
+- Auto-updater (tauri-plugin-updater + GitHub Releases, signed)
+- Cross-platform window focus by PID (Windows / macOS / Linux)
+- CI workflow: Rust fmt / clippy / test on every push and PR

--- a/index.html
+++ b/index.html
@@ -150,6 +150,11 @@
                 <p class="modal-text">
                   Activez le hook local ci-dessous pour remonter les pauses d’interaction de Claude Code sans exposer le token dans les logs.
                 </p>
+                <p class="modal-text doc-paths">
+                  Choisissez l’emplacement selon votre usage :<br>
+                  <strong>User-level</strong> (tous projets) : <code>~/.claude/settings.json</code><br>
+                  <strong>Project-level</strong> (un seul projet) : <code>&lt;project&gt;/.claude/settings.json</code>
+                </p>
               </section>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
                   <p class="guide-index">01</p>
                 <h3>Détection instantanée</h3>
                 <p class="modal-text">
-                  Cursor, Windsurf, Antigravity et VS Code sont détectés automatiquement dès qu’un projet est ouvert.
+                  Claude Code Terminal, Cursor, Windsurf, Antigravity et VS Code sont détectés automatiquement dès qu’un projet est ouvert.
                 </p>
               </section>
               <section class="guide-card">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsehub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "synapsehub"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapsehub"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SynapseHub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.synapsehub.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ const btnInstallUpdate = document.getElementById("btn-install-update") as HTMLBu
 const heroKicker = document.getElementById("hero-kicker")!;
 const heroTitle = document.getElementById("hero-title")!;
 const heroSubtitle = document.getElementById("hero-subtitle")!;
+const heroOrbit = document.querySelector<HTMLElement>(".hero-orbit");
 const runningCount = document.getElementById("running-count")!;
 const waitingCount = document.getElementById("waiting-count")!;
 const projectsCount = document.getElementById("projects-count")!;
@@ -367,7 +368,14 @@ function render(): void {
   }
 
   sectionCount.textContent = `${activeSessions.length} active${activeSessions.length > 1 ? "s" : ""}`;
-  emptyState.style.display = activeSessions.length === 0 ? "" : "none";
+  const isEmpty = activeSessions.length === 0;
+  emptyState.style.display = isEmpty ? "" : "none";
+  // Single visual focus: hero-orbit when at least one agent is active,
+  // empty-orbit when the dashboard is calm. Showing both was redundant
+  // and split the user's attention in the empty state.
+  if (heroOrbit) {
+    heroOrbit.style.display = isEmpty ? "none" : "";
+  }
 
   sortedSessions.forEach((session) => {
     agentList.appendChild(renderCard(session));

--- a/src/styles.css
+++ b/src/styles.css
@@ -762,6 +762,13 @@ body {
 
 .code-block {
   max-height: clamp(180px, 26vh, 260px);
+  /* `pre-wrap` lets the curl + token snippet wrap naturally on narrow
+   * windows so users can see the whole thing without horizontal
+   * scrolling. `word-break: break-all` covers the edge case of an
+   * unbroken 64-char token; `overflow-x: auto` stays as a last-resort
+   * fallback for content that genuinely cannot wrap. */
+  white-space: pre-wrap;
+  word-break: break-all;
   overflow-x: auto;
   overflow-y: auto;
   padding: 14px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -730,6 +730,21 @@ body {
   gap: 10px;
 }
 
+.doc-paths {
+  margin-top: 10px;
+  line-height: 1.6;
+}
+
+.doc-paths code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--cyan);
+}
+
 .code-block-wrapper {
   padding: 14px;
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -173,6 +173,12 @@ body {
   color: var(--cyan);
   font-size: 11px;
   font-weight: 600;
+  /* The header itself has `-webkit-app-region: drag`. Apply `no-drag`
+   * explicitly on the badge so clicks register cleanly instead of
+   * triggering a window drag — keeps it ready for a future onclick
+   * (settings shortcut, agent count tooltip, etc.). */
+  -webkit-app-region: no-drag;
+  cursor: pointer;
 }
 
 .dashboard-scroll {


### PR DESCRIPTION
## Summary

PR-B closes the v0.1.1 sprint. Companion to [PR #12](https://github.com/thierryvm/SynapseHub/pull/12) (security hardening, already merged).

| # | Finding | Commit |
|---|---|---|
| **#11** | Settings modal: Claude Code Terminal added to detected agents wording (was a doc/UI bug — backend already detects it) | `9c83c04` |
| **#14** | Settings modal: explicit user-level (`~/.claude/settings.json`) vs project-level (`<project>/.claude/settings.json`) hook paths | `70da987` |
| **#12** | `.code-block`: `white-space: pre-wrap` so the long curl + 64-char token wraps and stays fully visible | `3d5e938` |
| **#15** | `.agent-badge`: `-webkit-app-region: no-drag` + `cursor: pointer` so clicks register cleanly instead of dragging the window | `cdfe831` |
| **#13** | Single visual focus in empty state — `hero-orbit` hidden when no agents, `empty-orbit` hidden when at least one | `46bd9a5` |
| **#20** | `npm test` (vitest run) added to the Frontend CI job — the 7 existing TS tests now gate every PR | `aa62a4a` |
| — | `CHANGELOG.md` created (Keep a Changelog 1.1.0) with v0.1.1 entry + backfilled v0.1.0 baseline | `0c8b3a6` |
| **#24** | Version bumped to `0.1.1` across `package.json`, `Cargo.toml`, `tauri.conf.json`; `Cargo.lock` regenerated | `d378b02` |

## Decisions

- **#15 `.agent-badge`**: applied `no-drag` + `cursor: pointer` even though the badge has no onclick handler yet. The cursor change signals affordance and reserves the element for a likely future shortcut (tooltip, quick-jump to next waiting agent). The parent `.header-meta` already has `no-drag`, but propagation isn't reliable across all WebView2/Wry versions, so the leaf-level declaration is the safer fix.
- **#13 empty state**: chose to hide `.hero-orbit` rather than `.empty-orbit` in the empty state — the empty-orbit copy ("Le hub est calme pour l'instant") is more contextual when nothing is active. Reverse the toggle when at least one session is rendered.
- **CHANGELOG**: backfilled v0.1.0 baseline pinned to `2026-03-27` (initial commit date via `git log --reverse`).

## DoD 8-step (to verify post-merge)

- [ ] CI 100% green (Frontend install/build/**vitest**, Rust fmt/clippy/test/audit, Sourcery review)
- [ ] Sourcery silent on the latest commit (`gh api repos/thierryvm/SynapseHub/pulls/<N>/comments --jq '.[] | select(.user.login == "sourcery-ai[bot]") | .body'` returns empty)
- [ ] `mergeStateStatus: CLEAN`
- [ ] Rust tests ≥ 23 — no regression vs PR-A
- [ ] Vitest tests ≥ 7 — passing in CI for the first time
- [ ] Version `0.1.1` consistent across package.json, Cargo.toml, tauri.conf.json
- [ ] CHANGELOG.md v0.1.1 entry readable
- [ ] Final report deposited in `cc-handoffs/`

## Local quality gates (verified before push)

```
cargo fmt --check                   ✓
cargo clippy --all-targets -D warns ✓
cargo test --all-features           ✓ 23 passed (Windows; +1 Unix-only)
npx vitest run                      ✓ 7/7
npx tsc --noEmit                    ✓ clean
npm audit                           ✓ 0 vulnerabilities
npm run build                       ✓ vite 6.4.2 + tsc OK (150ms)
cargo audit                         ⚠ not installed locally — CI step covers it
```

## Refs

- Handoff: `cowork-handoffs/2026-04-29-1500-pr-b-ergonomics-tag-v0-1-1.md`
- Companion PR (already merged): #12
- Out of scope (v0.1.2 / v0.2.0): S5/S10/S11, host-check anti-DNS-rebinding, GitHub labels, folder watcher, Cowork focus, generic /notify webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)