### PR TITLE
fix(release): enable createUpdaterArtifacts + rotate minisign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2-rc.1] - 2026-04-29
+
+### Fixed
+- **release pipeline** — `createUpdaterArtifacts: true` ajouté dans `tauri.conf.json` `bundle`. Sans cette option, Tauri 2 stable n'émet ni `latest.json` ni les `.sig` updater (régression silencieuse côté framework, opt-in explicite obligatoire). C'est ce qui a empêché l'auto-update à v0.1.1. Référence : [#17](https://github.com/thierryvm/SynapseHub/issues/17).
+
+### Changed
+- Nouvelle paire de clés minisign générée pour repartir sur une chaîne de signing dont le password (vide) est documenté. Pubkey rotée dans `tauri.conf.json` (fingerprint `3877AE0A82FBBFE`, vs précédent `BD5AA9E173A8A318`).
+
+### Validation
+- `v0.1.2-rc.1` est tagged d'abord pour valider le pipeline (présence de `latest.json` + `.sig` dans les assets de la release). `v0.1.2` stable suit uniquement si la rc passe le gate post-build.
+
 ## [0.1.1] - 2026-04-29
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,81 +1,248 @@
+<div align="center">
+
 # SynapseHub
 
-> Cross-platform agent activity dashboard for Claude Code — Windows, macOS, Linux.
+**Cross-platform agent operations desk for Claude Code**
 
-SynapseHub lives in your system tray and tells you which Claude Code agents are active, on which project, and — critically — **which ones are waiting for your input**, even when their IDE is in the background.
+*Stop losing track of which agent is waiting for you.*
 
-Built with Tauri 2 + Rust + TypeScript. MIT licensed.
+[![Latest release](https://img.shields.io/github/v/release/thierryvm/SynapseHub?label=latest&color=22c55e)](https://github.com/thierryvm/SynapseHub/releases/latest)
+[![Build status](https://img.shields.io/github/actions/workflow/status/thierryvm/SynapseHub/release.yml?label=build)](https://github.com/thierryvm/SynapseHub/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/github/license/thierryvm/SynapseHub?color=blue)](LICENSE)
+[![Tauri 2](https://img.shields.io/badge/tauri-2-fdc28c?logo=tauri&logoColor=white)](https://tauri.app)
+[![Rust 1.80+](https://img.shields.io/badge/rust-1.80+-orange?logo=rust&logoColor=white)](https://www.rust-lang.org)
+[![TypeScript](https://img.shields.io/badge/typescript-5.7-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
----
+[**Download**](#-download) · [**Quick start**](#-quick-start) · [**Architecture**](#-architecture) · [**Roadmap**](#-roadmap) · [**Contributing**](CONTRIBUTING.md)
 
-## Why
-
-When working with multiple Claude Code sessions across Antigravity, Cursor, or a plain terminal, you lose track of which agent needs attention. Standard OS notifications only fire when the IDE is in the foreground. SynapseHub fixes this.
-
----
-
-## Features (v0.1)
-
-- **Agent dashboard** — see all active Claude Code sessions at a glance: project name, git branch, IDE, running time
-- **Waiting detection** — highlights agents waiting for input via Claude Code's `Stop` hook
-- **Native notifications** — OS-level alert when any agent needs you, regardless of which window is focused
-- **One-click focus** — click an agent card to bring its IDE window to the front
-- **Zero terminal required** — system tray app, starts with OS
+</div>
 
 ---
 
-## Stack
+## ✨ The problem SynapseHub solves
 
-| Layer | Technology |
-|---|---|
-| App shell | Tauri 2 |
-| Backend | Rust (axum, sysinfo, git2) |
-| UI | TypeScript + CSS (no framework) |
-| Notifications | tauri-plugin-notification |
-| CI/CD | GitHub Actions |
+When you run **multiple Claude Code sessions** across Antigravity, Cursor, VS Code, or a plain terminal, you lose track of which agent is doing what — and worse, **which one is waiting for your input**.
+
+Standard OS notifications only fire when the IDE window is in the foreground. So if you're working in another window, an agent that's waiting on you can sit idle for minutes — or hours.
+
+**SynapseHub fixes that.** It lives in your system tray, watches all your active Claude Code sessions, and sends a native OS notification the moment any of them needs your attention — no matter which window is focused.
+
+> [!NOTE]
+> **v0.1.1 is the first public release.** Functional MVP, core security hardening done, but the auto-updater pipeline is being repaired in v0.1.2 ([#17](https://github.com/thierryvm/SynapseHub/issues/17)). For now, install manually from the [release assets](https://github.com/thierryvm/SynapseHub/releases/latest). UX/UI rework planned for v0.2.0.
 
 ---
 
-## Quick start
+## 🎯 Features
 
-See [SETUP.md](SETUP.md) for prerequisites and build instructions.
+- **Live agent dashboard** — every active Claude Code session at a glance: project name, git branch, IDE host, running time
+- **Waiting-for-input detection** — highlights agents that have hit Claude Code's `Stop` hook
+- **Cross-window OS notifications** — native alerts via `tauri-plugin-notification`, regardless of which app is focused
+- **One-click window focus** — click an agent card and the IDE window jumps to the front
+- **System tray native** — runs quietly in the tray, starts with the OS, near-zero footprint
+- **Privacy by default** — 100% local. No telemetry. No cloud. The HTTP server only listens on `127.0.0.1`
+- **Cross-platform** — Windows (MSI/EXE), macOS Intel + Apple Silicon (DMG), Linux (.deb / AppImage)
+- **Hardened security baseline** — timing-safe token comparison, 64-char hex entropy, rate-limiting on the hook endpoint, file perms `0600` on Unix, hard `cargo audit` gate in CI
+
+---
+
+## 📦 Download
+
+Get the latest binaries from [**GitHub Releases**](https://github.com/thierryvm/SynapseHub/releases/latest).
+
+| Platform | Format | Notes |
+|---|---|---|
+| 🪟 Windows 10/11 | `.msi` (recommended) or `.exe` | Bundled installer, native tray |
+| 🍎 macOS 13+ Apple Silicon | `.dmg` | M1/M2/M3 optimized |
+| 🍎 macOS 13+ Intel | `.dmg` | x86_64 build |
+| 🐧 Linux (Debian/Ubuntu) | `.deb` | Tested on Ubuntu 22.04+ |
+| 🐧 Linux (other distros) | `.AppImage` | Portable, no install needed |
+
+Each release ships **9 binaries** built and (OS-) signed by GitHub Actions. macOS notarization and Windows signtool integration are handled by `tauri-action`.
+
+---
+
+## 🚀 Quick start
+
+### 1. Install SynapseHub
+
+Download the binary for your OS from [Releases](https://github.com/thierryvm/SynapseHub/releases/latest) and install. The app starts in your **system tray** (look for the icon — top-right on macOS, bottom-right on Windows, top-bar on most Linux DEs).
+
+### 2. Configure the Claude Code hook
+
+SynapseHub listens for Claude Code's `Stop` hook on a local-only HTTP endpoint, so it can detect when an agent is waiting for input.
+
+Open **Settings → Hook setup** in the SynapseHub UI to get the exact `settings.json` snippet to paste into your Claude Code config (with a freshly-generated 64-char hex token).
+
+A typical project-level hook looks like:
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "type": "command",
+      "command": "curl -X POST http://127.0.0.1:8765/hook -H 'X-SynapseHub-Token: <your-token>' -H 'Content-Type: application/json' -d '{}'"
+    }]
+  }
+}
+```
+
+> Full instructions including PowerShell helper, project-level vs user-level paths, and troubleshooting: [`docs/hook-setup.md`](docs/hook-setup.md).
+
+### 3. Launch your agents
+
+Run Claude Code as usual in any IDE. SynapseHub picks them up automatically and shows them in the dashboard. When an agent finishes a task and waits for input, you'll get a native OS notification with one-click focus.
+
+---
+
+## 🏗 Architecture
+
+```mermaid
+flowchart LR
+    subgraph IDEs["IDEs (Antigravity, Cursor, VS Code, Terminal)"]
+        CC1["Claude Code session #1"]
+        CC2["Claude Code session #2"]
+        CC3["Claude Code session N"]
+    end
+
+    subgraph SH["SynapseHub (Tauri 2)"]
+        Watcher["Rust watcher<br/>(~/.claude/ide/*.lock)"]
+        Server["axum HTTP server<br/>127.0.0.1:PORT<br/>(rate-limited, token-auth)"]
+        State["AppState<br/>(Arc&lt;Mutex&gt;)"]
+        UI["WebView dashboard<br/>(TS + CSS, no framework)"]
+        Tray["System tray + notifications"]
+    end
+
+    CC1 -. "lock file" .-> Watcher
+    CC2 -. "lock file" .-> Watcher
+    CC3 -- "POST /hook (Stop event)" --> Server
+    Watcher --> State
+    Server --> State
+    State --> UI
+    State --> Tray
+```
+
+Two complementary signals feed the same `AppState`:
+
+1. **Lock file polling** (every 2s) — detects which Claude Code sessions are alive, on which project, branch, and IDE
+2. **HTTP webhook** — fires when a session hits a `Stop` hook (i.e. waiting for user input)
+
+The HTTP server only binds to `127.0.0.1` — never exposed to the network. All `/hook` requests are token-authenticated (timing-safe comparison) and rate-limited to 10 req/s.
+
+---
+
+## 💻 Development
+
+### Prerequisites
+
+- **Node.js** 20.x+ (LTS recommended)
+- **Rust** 1.80+ (`rustup`)
+- **Platform-specific Tauri prerequisites** — see the [Tauri prerequisites guide](https://tauri.app/start/prerequisites/)
+- **Claude Code** installed (for end-to-end testing)
+
+### Setup
 
 ```bash
+git clone https://github.com/thierryvm/SynapseHub.git
+cd SynapseHub
 npm install
-npm run tauri dev   # development
-npm run tauri build # production
+
+# Run in dev mode (hot-reload UI + watch Rust)
+npm run tauri dev
+
+# Run TS + Rust tests
+npm test                 # vitest (frontend)
+cargo test --manifest-path src-tauri/Cargo.toml
+
+# Production build
+npm run tauri build
 ```
+
+### Project layout
+
+```
+src/                  # TypeScript + CSS frontend (no framework)
+src-tauri/
+  src/                # Rust backend (axum, sysinfo, git2)
+  Cargo.toml          # Rust deps + targets
+  tauri.conf.json     # App config (bundles, updater, capabilities)
+  audit.toml          # cargo audit ignores (with rationale + GitHub trackers)
+docs/                 # User docs (hook setup, etc.)
+.github/workflows/    # CI: lint, tests, release matrix (4 OS)
+scripts/              # Build helpers (icon generation, etc.)
+```
+
+See [`SETUP.md`](SETUP.md) for the full developer onboarding guide and [`AGENTS.md`](AGENTS.md) for codebase conventions.
 
 ---
 
-## Architecture
+## 🔒 Security
 
-```
-~/.claude/ide/*.lock   →  Rust watcher (polls every 2s)
-                               ↓
-                         AppState (Arc<Mutex>)
-                               ↓
-Claude Code Stop hook  →  axum HTTP server (127.0.0.1:PORT)
-                               ↓
-                         Tauri events → WebView dashboard
-```
+Security is treated as a first-class concern, not an afterthought.
 
----
+- **Token-based auth** on the `/hook` endpoint with **timing-safe comparison** (`subtle::ConstantTimeEq`)
+- **64-char hex entropy** for tokens (`OsRng`)
+- **Rate-limited** at 10 req/s via `tower_governor`
+- **File permissions `0600`** on `hook_token` (Unix)
+- **Server bound to `127.0.0.1` only** — never exposed to LAN
+- **`cargo audit` hard gate in CI** — release blocked on any unfixed advisory
+- **Documented advisory ignores** in `src-tauri/audit.toml` — every ignore has a rationale + a GitHub tracker issue with a clear exit condition
 
-## Roadmap
+For the full security posture, threat model, and supply-chain controls, see [`SECURITY.md`](SECURITY.md).
 
-- **v0.1** — Agent list + waiting detection + notifications + focus *(current)*
-- **v0.2** — Setup wizard (auto-configure Claude Code hooks), settings UI
-- **v0.3** — Multi-monitor support, custom notification sounds
-- **v1.0** — Stable API for plugins / community extensions
+To responsibly report a vulnerability, please follow the disclosure process described in `SECURITY.md`.
 
 ---
 
-## Contributing
+## 🗺 Roadmap
 
-PRs welcome. Please read [SETUP.md](SETUP.md) to get a dev environment running.
-File issues for bugs or feature requests.
+| Version | Focus | Status |
+|---|---|---|
+| **v0.1.1** | Public release — security hardening, ergonomics, CHANGELOG | ✅ Released 2026-04-29 |
+| **v0.1.2** | Auto-updater pipeline fix + UX (toast, manual check, restart) + sécurité Tier 4 | 🚧 In progress |
+| **v0.2.0** | Trio integration — generic webhook `POST /notify`, generic folder watcher (Obsidian vault), focus Cowork desktop | 📋 Planned |
+| **v0.3.0** | UX/UI global rework, multi-monitor support, custom notification sounds | 💡 Conceptual |
+| **v1.0.0** | Stable plugin API for community extensions | 🎯 Goal |
 
-## License
+Full roadmap and current sprint priorities: see [open milestones](https://github.com/thierryvm/SynapseHub/milestones) and [v0.1.2-candidate issues](https://github.com/thierryvm/SynapseHub/issues?q=is%3Aopen+label%3Av0.1.2-candidate).
 
-MIT — see [LICENSE](LICENSE).
+---
+
+## 📚 Documentation
+
+| Document | Purpose |
+|---|---|
+| [`SETUP.md`](SETUP.md) | Full developer onboarding (prereqs, build, test, troubleshoot) |
+| [`docs/hook-setup.md`](docs/hook-setup.md) | Configure the Claude Code `Stop` hook (project-level, user-level, PowerShell helper) |
+| [`docs/release-process.md`](docs/release-process.md) | End-to-end release workflow (sanity checks, tagging, monitoring, rollback) |
+| [`AGENTS.md`](AGENTS.md) | Codebase conventions and module-by-module guide for AI coding agents |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Branch strategy, commit conventions, PR checklist |
+| [`SECURITY.md`](SECURITY.md) | Security posture, threat model, vulnerability disclosure |
+| [`CHANGELOG.md`](CHANGELOG.md) | Versioned change log (Keep a Changelog 1.1.0) |
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome. Bug reports, feature requests, and pull requests all help.
+
+1. **Bug reports** — please use the [bug report template](https://github.com/thierryvm/SynapseHub/issues/new?template=bug_report.md)
+2. **Feature requests** — [feature request template](https://github.com/thierryvm/SynapseHub/issues/new?template=feature_request.md)
+3. **Pull requests** — read [`CONTRIBUTING.md`](CONTRIBUTING.md) first; small, atomic, well-tested PRs preferred
+
+All PRs are reviewed and must pass the full CI matrix (lint, TypeScript check, Rust tests, Vitest, `cargo audit`) before merge.
+
+---
+
+## 📝 License
+
+[MIT](LICENSE) — © 2026 Thierry Vanmeeteren
+
+---
+
+<div align="center">
+
+**Built with [Tauri 2](https://tauri.app), [Rust](https://www.rust-lang.org), and a lot of `cargo audit` runs.**
+
+[Report an issue](https://github.com/thierryvm/SynapseHub/issues) · [Latest release](https://github.com/thierryvm/SynapseHub/releases/latest) · [Discussions](https://github.com/thierryvm/SynapseHub/discussions)
+
+</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsehub",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "synapsehub"
-version = "0.1.1"
+version = "0.1.2-rc.1"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapsehub"
-version = "0.1.1"
+version = "0.1.2-rc.1"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SynapseHub",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.1",
   "identifier": "com.synapsehub.app",
   "build": {
     "frontendDist": "../dist",
@@ -34,6 +34,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",
@@ -46,7 +47,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJENUFBOUUxNzNBOEEzMTgKUldRWW82aHo0YWxhdmEwb2F1eTVZVVZNc3Q1SWRuczhRZzdMbjk1d0h5bDIwUTd5d2ZwaGQzeCsK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM4NzdBRTBBODJGQkJGRQpSV1QrdXkrbzRIcUhBMU1QOUtmMkxZTWtUOG8xaExEVnZDWWVsUmdIZ2x6N3EyeVVHWDdCZ21GVgo=",
       "endpoints": [
         "https://github.com/thierryvm/SynapseHub/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
Fixes #17.

This PR fixes the silent updater pipeline regression discovered during the v0.1.1 release. Root cause was **not** the secret (as initially suspected) but the missing `createUpdaterArtifacts: true` option in `tauri.conf.json` `bundle` config — since Tauri 2 stable, this flag is opt-in explicit. Without it, `tauri-action` correctly logs `Signature not found for the updater JSON. Skipping upload...` and ships the binaries without `latest.json` / `.sig`.

## Changes

1. `src-tauri/tauri.conf.json` — `"createUpdaterArtifacts": true` added to `bundle`
2. Minisign keypair rotated (the previous one had a forgotten password). New pubkey fingerprint: `3877AE0A82FBBFE` (was `BD5AA9E173A8A318`). Both GitHub secrets re-set via `gh secret set` direct from file (no key value in any conversation log)
3. Version bumped `0.1.1` → `0.1.2-rc.1` in `tauri.conf.json`, `Cargo.toml`, `package.json`. `Cargo.lock` regenerated via `cargo check`
4. `CHANGELOG.md` gains a `[0.1.2-rc.1]` entry with `Fixed` / `Changed` / `Validation` sections

## Validation plan

- [ ] CI green (Frontend install/build/vitest, Rust fmt/clippy/test/audit, Sourcery review)
- [ ] Sourcery silent on the latest commit
- [ ] After merge: tag `v0.1.2-rc.1`, watch `release.yml`
- [ ] Verify `gh release view v0.1.2-rc.1 --json assets` contains:
  - [ ] `latest.json` (the manifest `tauri-plugin-updater::check()` fetches)
  - [ ] `.sig` next to each main binary (~9 sigs total — Win MSI/EXE, macOS DMG×2 + tar.gz×2, Linux deb/AppImage/rpm)
- [ ] If clean: bump to `0.1.2` stable in a follow-up PR (`chore/v0.1.2-stable`), retag as `v0.1.2`

## Local quality gates (verified before push)

```
cargo fmt --check                   ✓
cargo clippy --all-targets -D warns ✓ 0 warnings
cargo test --all-features           ✓ 23/23 passing
npx vitest run                      ✓ 7/7
npx tsc --noEmit                    ✓ clean
npm audit                           ✓ 0 vulnerabilities
npm run build                       ✓ vite 6.4.2 OK (136ms)
```

## Refs

- Sprint v0.1.2 PR-C handoff: `cowork-handoffs/2026-04-29-1830-v0-1-2-pr-c-updater-fix.md`
- Investigation diagnostique (issue #17 enrichie): https://github.com/thierryvm/SynapseHub/issues/17#issuecomment-4344716813
- Doc canonique release process: `docs/release-process.md` (PR #19, mergée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)