### PR TITLE
chore(release): promote 0.1.2-rc.1 to 0.1.2 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-29
+
+### Fixed
+- **Updater pipeline** — `createUpdaterArtifacts: true` ajouté dans `tauri.conf.json` `bundle` (validé sur 3/4 OS via la rc.1 : Linux + macOS Intel + macOS Apple Silicon ont tous publié `latest.json` + `.sig`). Sans cette ligne, Tauri 2 stable ne génère pas les artefacts updater. Référence : [#17](https://github.com/thierryvm/SynapseHub/issues/17).
+- **Windows MSI version format** — pre-release suffix retiré pour respecter la contrainte `MAJOR.MINOR.PATCH.BUILD` numeric-only de WiX/MSI. La rc.1 avait fail sur ce point spécifique (`0.1.2-rc.1` rejeté par le bundler MSI), résolu par construction en taggant directement `0.1.2`.
+
+### Changed
+- Nouvelle paire de clés minisign générée. Pubkey rotée dans `tauri.conf.json` (fingerprint `3877AE0A82FBBFE`, vs précédent `BD5AA9E173A8A318`). Les anciens binaires v0.1.1 ne pourront pas valider les updates v0.1.2 — réinstall manuelle requise pour les early adopters de v0.1.1.
+
 ## [0.1.2-rc.1] - 2026-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Updater pipeline** — `createUpdaterArtifacts: true` ajouté dans `tauri.conf.json` `bundle` (validé sur 3/4 OS via la rc.1 : Linux + macOS Intel + macOS Apple Silicon ont tous publié `latest.json` + `.sig`). Sans cette ligne, Tauri 2 stable ne génère pas les artefacts updater. Référence : [#17](https://github.com/thierryvm/SynapseHub/issues/17).
-- **Windows MSI version format** — pre-release suffix retiré pour respecter la contrainte `MAJOR.MINOR.PATCH.BUILD` numeric-only de WiX/MSI. La rc.1 avait fail sur ce point spécifique (`0.1.2-rc.1` rejeté par le bundler MSI), résolu par construction en taggant directement `0.1.2`.
+- **Windows MSI version format** — pre-release suffix retiré pour respecter la contrainte `MAJOR.MINOR.PATCH.BUILD` numeric-only de WiX/MSI. La rc.1 avait fail sur ce point spécifique (`0.1.2-rc.1` rejeté par le bundler MSI), résolu par construction en taguant directement `0.1.2`.
 
 ### Changed
 - Nouvelle paire de clés minisign générée. Pubkey rotée dans `tauri.conf.json` (fingerprint `3877AE0A82FBBFE`, vs précédent `BD5AA9E173A8A318`). Les anciens binaires v0.1.1 ne pourront pas valider les updates v0.1.2 — réinstall manuelle requise pour les early adopters de v0.1.1.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsehub",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "synapsehub"
-version = "0.1.2-rc.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapsehub"
-version = "0.1.2-rc.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SynapseHub",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2",
   "identifier": "com.synapsehub.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Promotes the validated rc.1 to stable v0.1.2.

## Validation summary (rc.1)

`createUpdaterArtifacts: true` confirmed on 3/4 OS in [v0.1.2-rc.1 release](https://github.com/thierryvm/SynapseHub/releases/tag/v0.1.2-rc.1):

| OS | Bundles | `.sig` | `latest.json` |
|---|---|---|---|
| ✅ Linux | `.deb`, `.AppImage`, `.rpm` | ✅ 3 sigs | ✅ |
| ✅ macOS Intel | `.dmg`, `.app.tar.gz` | ✅ on tar.gz | ✅ |
| ✅ macOS Apple Silicon | `.dmg`, `.app.tar.gz` | ✅ on tar.gz | ✅ |
| ❌ Windows MSI | (rc.1 build failed) | — | — |

Windows MSI failure cause (rc.1):

```
failed to bundle project: optional pre-release identifier in app version
must be numeric-only and cannot be greater than 65535 for msi target
```

WiX bundler rejects `-rc.1` because pre-release identifiers in MSI must be numeric. **Fix by construction**: tag directly as `0.1.2` (numeric-only, same shape as v0.1.1 which built clean on Windows).

## Changes

Three sources of truth bumped `0.1.2-rc.1` → `0.1.2`:
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `package.json`

`Cargo.lock` regenerated. `CHANGELOG.md` gains a `[0.1.2]` entry above the existing `[0.1.2-rc.1]` entry (kept for historical traceability).

## Validation plan v0.1.2

- [ ] CI green (Frontend install/build/vitest, Rust fmt/clippy/test/audit, Sourcery review)
- [ ] Sourcery silent on the latest commit
- [ ] After merge: tag `v0.1.2`, monitor `release.yml` on **all 4 OS this time**
- [ ] Verify `gh release view v0.1.2 --json assets` contains:
  - [ ] `latest.json`
  - [ ] Windows: `.msi` + `.exe` (was missing in rc.1)
  - [ ] macOS: `.dmg` ×2 + `.app.tar.gz` ×2 + 2 `.sig`
  - [ ] Linux: `.deb` + `.AppImage` + `.rpm` + 3 `.sig`
- [ ] If Windows fails again → STOP, mark v0.1.2 as prerelease, diagnose, do not promote

## Refs

- Sprint v0.1.2 PR-C handoff: `cowork-handoffs/2026-04-29-1830-v0-1-2-pr-c-updater-fix.md`
- rc.1 release: https://github.com/thierryvm/SynapseHub/releases/tag/v0.1.2-rc.1
- Issue #17 (auto-closed by previous PR #22 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Promouvoir l’application de la préversion 0.1.2-rc.1 vers la version stable 0.1.2 et documenter les changements concernant le système de mise à jour et la signature.

Corrections de bugs :
- Garantir la génération des artefacts du système de mise à jour en activant la création de bundles Tauri updater pour la v0.1.2.
- Résoudre l’échec du packaging MSI Windows en remplaçant la chaîne de version préversion par une version purement numérique 0.1.2.

Améliorations :
- Faire tourner la paire de clés minisign et mettre à jour la clé publique utilisée pour la signature des releases, ce qui nécessite une réinstallation manuelle pour les utilisateurs existants de la version 0.1.1.

Tâches diverses :
- Mettre à jour les versions du projet de 0.1.2-rc.1 à 0.1.2 dans tous les fichiers de configuration et régénérer `Cargo.lock`.
- Ajouter une entrée 0.1.2 au changelog décrivant les changements liés au système de mise à jour, au MSI Windows et à la signature.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Promote the app from prerelease 0.1.2-rc.1 to stable 0.1.2 and document the updater and signing changes.

Bug Fixes:
- Ensure updater artifacts are generated by enabling Tauri updater bundling for v0.1.2.
- Resolve Windows MSI packaging failure by switching from a prerelease version string to a numeric-only 0.1.2 version.

Enhancements:
- Rotate the minisign keypair and update the public key used for release signing, requiring manual reinstall for existing 0.1.1 users.

Chores:
- Bump project versions from 0.1.2-rc.1 to 0.1.2 across configuration files and regenerate Cargo.lock.
- Add a 0.1.2 entry to the changelog describing updater, Windows MSI, and signing changes.

</details>