### PR TITLE
fix(watcher): detect Claude Code Terminal CLI v2026 on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-29
+
+### Fixed
+- **Watcher Windows — détection Claude Code Terminal CLI v2026** ([#24](https://github.com/thierryvm/SynapseHub/issues/24)). Le pattern matching dans `detect_ide_name` était trop restrictif (`claude-code`, `@anthropic-ai`, `claude.cmd` uniquement) et misclassifiait les sessions CC Terminal CLI v2026 sur Windows comme `Claude Desktop`. La cmd line v2026 est ultra-minimaliste (`claude  --dangerously-skip-permissions -c`), sans path préfixe. Patterns élargis : `claude` / `claude.exe` / `"claude" ` (bare-name invocations), avec garde anti-faux-positif sur `\windowsapps\claude_` qui distingue l'Electron desktop.
+- **Distinction Claude Desktop vs CC Terminal** — la branche Claude Desktop est désormais positivement gatée sur le path complet WindowsApps (Windows) ou `/applications/claude.app/` (macOS). Un `claude.exe` orphelin sans préfixe de path est traité comme CC Terminal et non plus comme Desktop.
+- **Résolution `cwd` sur Windows** — le `RefreshKind` du watcher n'appelait jamais `.with_cwd(...)`, ce qui faisait que sysinfo Windows ne populait jamais le field `cwd` (cf. `sysinfo-0.33.1/src/windows/process.rs:816`). Conséquence : `process.cwd()` retournait `None` pour tous les processes, et la résolution du project path retombait silencieusement sur l'args fallback qui échoue pour CC Terminal CLI v2026 (cmd line sans path). Ajout de `.with_cwd(UpdateKind::OnlyIfNotSet)` aux deux `ProcessRefreshKind` (init + refresh loop).
+
+### Tests
+- 4 nouveaux tests unitaires dans `watcher::tests` :
+  - `detects_claude_code_terminal_cli_v2026_windows` — reproduce @thierry smoke-test
+  - `detects_claude_code_terminal_cli_minimal` — invocation `claude` seule
+  - `does_not_misclassify_claude_desktop_as_terminal` — primary process WindowsApps
+  - `does_not_misclassify_claude_desktop_subprocess_as_terminal` — Electron renderer/utility
+- Tests Rust : 23 → 27 (Windows local). Régression-safe : les 9 tests `watcher::tests` existants restent verts.
+
+### Documentation
+- Note d'investigation `analysis/2026-04-29-watcher-windows-cwd-investigation.md` (cause primaire, cause secondaire, sources sysinfo cross-checkées) pour traçabilité du diagnostic.
+
 ## [0.1.2] - 2026-04-29
 
 ### Fixed

--- a/analysis/2026-04-29-watcher-windows-cwd-investigation.md
+++ b/analysis/2026-04-29-watcher-windows-cwd-investigation.md
@@ -1,0 +1,163 @@
+# Watcher Windows — investigation cwd / detect_ide_name (29 avril 2026)
+
+Pre-implementation investigation for the v0.1.3 hotfix sprint
+([handoff](../cowork-handoffs/2026-04-29-2030-v0-1-3-hotfix-watcher.md), issue tracked on the parent PR).
+
+## Symptom
+
+SynapseHub v0.1.2 reports **0 active sessions** even though three Claude Code
+Terminal CLI sessions are running on Windows. Process snapshot from
+@thierry's machine:
+
+```
+ProcessId : 16344
+Name      : claude.exe
+CommandLine: claude  --dangerously-skip-permissions -c
+
+ProcessId : 17352
+Name      : claude.exe
+CommandLine: claude  --dangerously-skip-permissions -c
+```
+
+Two layers of the watcher need attention.
+
+## Layer 1 — `detect_ide_name` pattern matching
+
+Current implementation (`src-tauri/src/watcher.rs`, lines 128-134):
+
+```rust
+if cmd_joined.contains("claude-code")
+    || cmd_joined.contains("@anthropic-ai")
+    || cmd_joined.contains("claude.cmd")
+{
+    return Some("Claude Code Terminal");
+}
+```
+
+The CC Terminal CLI v2026 cmd line is `claude --dangerously-skip-permissions -c`
+— it contains **none** of the three substrings. Detection falls through to
+the generic branch at line 150:
+
+```rust
+} else if name_lower.contains("claude.exe") || name_lower.contains("claude desktop") {
+    Some("Claude Desktop")
+}
+```
+
+So every CC Terminal CLI session is silently misclassified as Claude
+Desktop. From there, `resolve_project_path` either returns `None` (cf. Layer
+2) or an irrelevant path, and the session is dropped or merged with a
+phantom Desktop entry.
+
+### Distinguishing the two
+
+The CC Terminal CLI cmd line is a relative-name invocation
+(`claude  --dangerously-skip-permissions -c`).
+
+The desktop Electron app, when present on Windows, runs from
+`C:\Program Files\WindowsApps\Claude_<version>_x64__<id>\app\claude.exe`
+and its cmd line carries the full path. We can branch cleanly on the
+presence of `\windowsapps\claude_` (case-insensitive, since `cmd_joined`
+is already lowercased upstream).
+
+Patterns to add for CC Terminal:
+- `cmd_joined.starts_with("claude ")`
+- `cmd_joined.starts_with("claude.exe ")` AND **not** containing `\windowsapps\`
+- `cmd_joined.starts_with("\"claude\" ")` (quoted invocations seen in some shells)
+
+Anti false-positive: keep the `\windowsapps\claude_` test as a guard
+clause before returning `"Claude Code Terminal"`.
+
+The existing branch for Claude Desktop becomes positively gated:
+return `"Claude Desktop"` **only** when the cmd line carries
+`\windowsapps\claude_` (Windows) or `/applications/claude.app/`
+(macOS, harmless on Windows). A bare `claude.exe` with no path-prefix
+has no business being labelled as Desktop and we return `None` so the
+process is ignored cleanly.
+
+## Layer 2 — `process.cwd()` is never populated
+
+The watcher builds its `RefreshKind` like this (lines 364-369):
+
+```rust
+let refresh_kind = RefreshKind::nothing().with_processes(
+    ProcessRefreshKind::nothing()
+        .with_cpu()
+        .with_exe(UpdateKind::OnlyIfNotSet)
+        .with_cmd(UpdateKind::OnlyIfNotSet),
+);
+```
+
+And refreshes with the same shape (lines 379-383). Notice **`.with_cwd(...)`
+is absent**.
+
+Cross-checked against the sysinfo 0.33.1 source on Windows
+(`~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sysinfo-0.33.1/src/windows/process.rs`):
+
+```rust
+// line 647 (Process::refresh path):
+|| refresh_kind.cwd().needs_update(|| process.cwd.is_none())
+
+// line 816 (initial process collection):
+let cwd_needs_update = refresh_kind.cwd().needs_update(|| cwd.is_none());
+// ...
+// line 823: only when cwd_needs_update is true does it actually call
+// QueryProcessImageName / read PEB to populate cwd. Otherwise the field
+// stays None forever.
+```
+
+Conclusion: as long as we never call `.with_cwd(...)`, **`process.cwd()`
+returns `None` for every process on every poll**, regardless of OS. The
+fact that the dashboard occasionally surfaces sessions on macOS/Linux
+today is incidental — the lock-file path (`scan_lock_files`) does not
+need cwd, and the args fallback in `resolve_project_path` happens to
+produce a result in some cases. CC Terminal CLI v2026 carries no path
+in its argv, so the args fallback fails too, leaving us with nothing.
+
+### Fix shape
+
+Add `.with_cwd(UpdateKind::OnlyIfNotSet)` to both `ProcessRefreshKind`
+builders. `OnlyIfNotSet` keeps the cost down: the cwd is read once per
+process and reused across polls until that process exits.
+
+We also keep the existing args fallback (`looks_like_project_path_arg`)
+as a defense-in-depth for processes that genuinely have no readable cwd
+(some sandboxed / restricted-token scenarios on Windows 11).
+
+The handoff suggested two further fallbacks (parent process cwd, env
+`PWD`). Neither is needed if `with_cwd` itself is the missing piece:
+once it's set, the kernel-side `QueryProcessImageName` path runs and
+returns the real working directory the process was spawned in. If real
+production data later shows persistent gaps despite `with_cwd`, we can
+add the parent-cwd fallback in a follow-up patch.
+
+## Sanity check on existing tests
+
+`watcher.rs` has 10 unit tests today. The relevant one for this fix:
+
+- `detects_claude_code_from_command_line_signature` (line 549) — tests
+  the `claude-code` substring path. **Stays green** because we keep
+  that branch unchanged.
+
+The cwd refresh fix is purely a runtime data-collection question; it
+cannot be unit-tested without a real `sysinfo::Process` fixture.
+Coverage there comes from the @thierry smoke test (Phase 11 of the
+handoff).
+
+## Plan
+
+1. Update `detect_ide_name` to add the CC Terminal CLI v2026 patterns
+   and gate the Claude Desktop return on the WindowsApps path.
+2. Add `.with_cwd(UpdateKind::OnlyIfNotSet)` to both RefreshKind
+   builders in `start_watcher`.
+3. Four new unit tests in `watcher::tests`:
+   - `detects_claude_code_terminal_cli_v2026_windows`
+   - `detects_claude_code_terminal_cli_minimal`
+   - `does_not_misclassify_claude_desktop_as_terminal`
+   - `does_not_misclassify_claude_desktop_subprocess_as_terminal`
+4. Bump 0.1.2 → 0.1.3 across the three sources of truth.
+5. Update CHANGELOG.
+6. Commit, push, PR with `Fixes #<issue>`.
+
+Confidence: **high**. Both root causes are mechanically observable in
+the source — no environmental guesswork.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsehub",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "synapsehub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapsehub"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -125,11 +125,26 @@ fn resolve_project_path(process: &sysinfo::Process) -> Option<String> {
 }
 
 /// Maps known process names or command-line signatures to a UI-facing agent name.
+///
+/// `cmd_joined` is expected to be lowercase already (the caller in
+/// `scan_processes` lowercases each cmd arg before joining).
 fn detect_ide_name(name_lower: &str, cmd_joined: &str) -> Option<&'static str> {
-    if cmd_joined.contains("claude-code")
+    // Claude Code Terminal CLI — multiple signatures across versions:
+    // - Pre-v2026: `node claude-code …`, `@anthropic-ai/…`, or `claude.cmd`
+    // - v2026 Windows: `claude --dangerously-skip-permissions -c` — bare
+    //   binary, no path prefix. Distinguished from Claude Desktop by the
+    //   absence of `\windowsapps\claude_` (which is what the desktop
+    //   Electron bundle carries on Windows).
+    let is_claude_code_legacy = cmd_joined.contains("claude-code")
         || cmd_joined.contains("@anthropic-ai")
-        || cmd_joined.contains("claude.cmd")
-    {
+        || cmd_joined.contains("claude.cmd");
+    let is_claude_terminal_v2026 = (cmd_joined == "claude"
+        || cmd_joined == "claude.exe"
+        || cmd_joined.starts_with("claude ")
+        || cmd_joined.starts_with("claude.exe ")
+        || cmd_joined.starts_with("\"claude\" "))
+        && !cmd_joined.contains("\\windowsapps\\claude_");
+    if is_claude_code_legacy || is_claude_terminal_v2026 {
         return Some("Claude Code Terminal");
     }
 
@@ -147,7 +162,15 @@ fn detect_ide_name(name_lower: &str, cmd_joined: &str) -> Option<&'static str> {
         Some("Cursor")
     } else if name_lower.contains("windsurf") {
         Some("Windsurf")
-    } else if name_lower.contains("claude.exe") || name_lower.contains("claude desktop") {
+    } else if name_lower.contains("claude desktop")
+        || cmd_joined.contains("\\windowsapps\\claude_")
+        || cmd_joined.contains("/applications/claude.app/")
+    {
+        // Claude Desktop is recognised by the Electron bundle path: the
+        // WindowsApps installer on Windows or the `.app` bundle on macOS.
+        // A bare `claude.exe` without one of those prefixes is the CLI
+        // and was already handled above; falling through here means we
+        // intentionally ignore it rather than mislabel it as Desktop.
         Some("Claude Desktop")
     } else if name_lower.contains("code") && name_lower != "node.exe" {
         Some("VSCode")
@@ -360,26 +383,41 @@ fn scan_processes(
 pub async fn start_watcher(state: Arc<Mutex<AppState>>, app: AppHandle) {
     use sysinfo::{ProcessRefreshKind, RefreshKind, UpdateKind};
 
-    // Optimisation majeure du CPU : on informe sysinfo de ne scanner que le strict nécessaire
+    // CPU optimisation: only collect the fields we actually consume
+    // downstream (cpu / exe / cmd / cwd). `OnlyIfNotSet` means each field
+    // is read once per process and reused across polls until that process
+    // exits, so adding `cwd` here costs one PEB read per new process and
+    // nothing per refresh.
+    //
+    // `with_cwd` is mandatory: without it, sysinfo Windows leaves
+    // `process.cwd()` returning `None` for every process (cf. sysinfo
+    // 0.33.1 src/windows/process.rs:816 — `cwd_needs_update` short-circuits
+    // unless the refresh kind explicitly asks for it). That broke project
+    // path resolution for Claude Code Terminal CLI sessions whose cmd
+    // line carries no path argument to fall back on.
     let refresh_kind = RefreshKind::nothing().with_processes(
         ProcessRefreshKind::nothing()
             .with_cpu()
             .with_exe(UpdateKind::OnlyIfNotSet)
-            .with_cmd(UpdateKind::OnlyIfNotSet), // On ne demande ni la RAM ni le CPU de chaque process, ce qui est très lourd
+            .with_cmd(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::OnlyIfNotSet),
     );
     let mut sys = System::new_with_specifics(refresh_kind);
     let mut start_times: HashMap<String, u64> = HashMap::new();
     let mut resume_votes: HashMap<String, u8> = HashMap::new();
 
     loop {
-        // Refresh uniquement ce qui est nécessaire très rapidement
+        // Keep the refresh shape in sync with the initial RefreshKind above
+        // — the same `with_cwd(...)` is required here for new processes
+        // discovered between polls.
         sys.refresh_processes_specifics(
             sysinfo::ProcessesToUpdate::All,
             true,
             ProcessRefreshKind::nothing()
                 .with_cpu()
                 .with_exe(UpdateKind::OnlyIfNotSet)
-                .with_cmd(UpdateKind::OnlyIfNotSet),
+                .with_cmd(UpdateKind::OnlyIfNotSet)
+                .with_cwd(UpdateKind::OnlyIfNotSet),
         );
 
         let waiting_since = {
@@ -554,6 +592,56 @@ mod tests {
                 "node claude-code --project F:\\\\PROJECTS\\\\Apps\\\\SynapseHub"
             ),
             Some("Claude Code Terminal")
+        );
+    }
+
+    #[test]
+    fn detects_claude_code_terminal_cli_v2026_windows() {
+        // Reproduces @thierry's smoke-test scenario on v0.1.2: bare
+        // `claude` invocation with the typical CC Terminal CLI flags,
+        // no path prefix, name = `claude.exe`.
+        assert_eq!(
+            detect_ide_name("claude.exe", "claude  --dangerously-skip-permissions -c"),
+            Some("Claude Code Terminal")
+        );
+    }
+
+    #[test]
+    fn detects_claude_code_terminal_cli_minimal() {
+        // Edge case: a shell where the user typed just `claude` with no
+        // arguments. We still want to surface it.
+        assert_eq!(
+            detect_ide_name("claude.exe", "claude"),
+            Some("Claude Code Terminal")
+        );
+    }
+
+    #[test]
+    fn does_not_misclassify_claude_desktop_as_terminal() {
+        // The desktop Electron app on Windows ships under a versioned
+        // WindowsApps directory. The cmd line carries the full path,
+        // which is the discriminator we use to keep it labelled as the
+        // Desktop app, not the CLI.
+        assert_eq!(
+            detect_ide_name(
+                "claude.exe",
+                r#""c:\program files\windowsapps\claude_1.5354.0.0_x64__pzs8sxrjxfjjc\app\claude.exe""#
+            ),
+            Some("Claude Desktop")
+        );
+    }
+
+    #[test]
+    fn does_not_misclassify_claude_desktop_subprocess_as_terminal() {
+        // Electron renderer / utility sub-processes inherit the same
+        // WindowsApps path prefix and add a `--type=…` flag. Same
+        // discrimination rule applies.
+        assert_eq!(
+            detect_ide_name(
+                "claude.exe",
+                r#""c:\program files\windowsapps\claude_1.5354.0.0_x64__pzs8sxrjxfjjc\app\claude.exe" --type=renderer"#
+            ),
+            Some("Claude Desktop")
         );
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SynapseHub",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.synapsehub.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Fixes #24.

## Bug

SynapseHub v0.1.2 displays **0 active sessions** even when several Claude Code Terminal CLI sessions are running on Windows. Two coupled root causes (full diagnostic in `analysis/2026-04-29-watcher-windows-cwd-investigation.md`) :

1. **Pattern matching** in `detect_ide_name` was missing the v2026 CLI signature (`claude  --dangerously-skip-permissions -c` — bare binary, no path prefix). Sessions were misclassified as "Claude Desktop" via the catch-all `name_lower.contains("claude.exe")` branch and dropped further down the pipeline.
2. **`process.cwd()` always returned `None`** on Windows because the watcher's `RefreshKind` never called `.with_cwd(...)`. sysinfo 0.33.1 on Windows reads the cwd via PEB only when `refresh_kind.cwd().needs_update(...)` is true (verified in source `windows/process.rs:816`). Project path resolution then fell through to the args fallback, which also fails for v2026 CC Terminal CLI (cmd line carries no path arg).

## Fix

1. **Extended `detect_ide_name`** : new patterns `claude` / `claude.exe` / `"claude" ` (bare invocations) with anti-false-positive guard on `\windowsapps\claude_` to keep the Claude Desktop Electron bundle out of the CC Terminal branch. Claude Desktop branch is now positively gated on the WindowsApps path (Windows) or `/applications/claude.app/` (macOS).
2. **Added `.with_cwd(UpdateKind::OnlyIfNotSet)`** to both `ProcessRefreshKind` builders (init + refresh loop). `OnlyIfNotSet` keeps the cost down — one PEB read per new process, reused across polls.
3. **4 new unit tests** in `watcher::tests` covering the v2026 minimal cmd line, the `claude` standalone case, and two anti-false-positive cases (Claude Desktop primary process + sub-process renderer).
4. **Bump 0.1.2 → 0.1.3** across `tauri.conf.json`, `Cargo.toml`, `package.json` (Cargo.lock regenerated).

## Tests

- 23 → **27** Rust tests (Windows local). All previous tests remain green (regression-safe).
- 7/7 Vitest unchanged.
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo audit` (with documented ignores) all clean.

## Validation plan

- [ ] CI green (Frontend install/build/vitest, Rust fmt/clippy/test/audit, Sourcery review)
- [ ] Sourcery silent on the latest commit
- [ ] After merge: tag `v0.1.3`, monitor `release.yml` on the 4 OS
- [ ] Verify `gh release view v0.1.3` lists `latest.json` + `.sig` + binaries (4 OS)
- [ ] **Smoke test @thierry** : install v0.1.3 manually, launch 3 Claude Code Terminal CLI sessions in 3 PowerShells (different projects), open SynapseHub, confirm the dashboard shows 3 sessions with correct `project_path`, `git_branch`, and `ide_name = "Claude Code Terminal"`.
- [ ] No regression on existing detection (Cursor / VSCode / Antigravity / Codex / claude-code legacy patterns)

## Refs

- Sprint v0.1.3 hotfix handoff : `cowork-handoffs/2026-04-29-2030-v0-1-3-hotfix-watcher.md`
- Diagnostic complet : `analysis/2026-04-29-watcher-windows-cwd-investigation.md`
- Issue : #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)