### PR TITLE
fix(focus): auto-hide SynapseHub after successful focus_window (v0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-04-30
+
+### Fixed
+- **One-click focus visible** — auto-hide du dashboard SynapseHub après un focus IDE réussi. Diagnostic complet via console DevTools v0.1.4 (interceptor `__TAURI_INTERNALS__.invoke`, `getEventListeners`, body-capture) : le pipe complet (listener click → invoke → Rust `focus_window` → parent chain walk → `SetForegroundWindow`) marche, Windows passe bien le focus clavier sur Windows Terminal (Alt+Tab confirme), MAIS la dashboard reste visuellement par-dessus à cause de `alwaysOnTop: true` configuré pour le pattern "tray companion". Fix : appel à `invoke("hide_window")` quand `focus_window` retourne `true`. Le user rouvre SynapseHub via l'icône systray (workflow naturel : click "focus IDE" = je veux voir l'IDE, pas garder SynapseHub par-dessus). Si `focus_window` retourne `false` (process orphelin / terminal fermé), on ne hide pas et on log un `console.warn` explicite — l'utilisateur garde la visibilité du dashboard pour comprendre.
+
 ## [0.1.4] - 2026-04-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsehub",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "synapsehub"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "axum",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapsehub"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SynapseHub",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.synapsehub.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/main.ts
+++ b/src/main.ts
@@ -320,7 +320,14 @@ function renderCard(session: AgentSession): HTMLElement {
     if (canFocusWindow) {
       invoke<boolean>("focus_window", { pid: session.pid })
         .then((focused) => {
-          if (!focused) {
+          if (focused) {
+            // The dashboard window has `alwaysOnTop: true`, so even though
+            // SetForegroundWindow succeeds on the IDE, SynapseHub still
+            // visually covers it. Hide ourselves so the IDE actually
+            // becomes the visible window. The user re-opens SynapseHub
+            // through the tray icon when they need it back.
+            invoke("hide_window").catch(console.error);
+          } else {
             console.warn(
               `focus_window(${session.pid}) → no window found in parent chain (terminal may have closed)`,
             );


### PR DESCRIPTION
## Summary

Hotfix sprint v0.1.5 — résout le bug UX résiduel de v0.1.4 : le focus IDE marche techniquement mais reste invisible sous la dashboard `alwaysOnTop`.

## Diagnostic récap

Long debug croisé via console DevTools v0.1.4 (DevTools temporairement activés en v0.1.4 justement pour ça). Verdict :

- ✅ Listener click attaché à `.agent-card` (`getEventListeners` confirme)
- ✅ Events bubble jusqu'à `body` (capture phase confirme)
- ✅ `invoke('focus_window')` est appelé au clic (interceptor `__TAURI_INTERNALS__.invoke` confirme)
- ✅ Rust `focus_window` retourne `true` (parent chain walk trouve `WindowsTerminal.exe`)
- ✅ Windows transfère le focus clavier (Alt+Tab post-click confirme)
- ❌ MAIS la dashboard reste visuellement par-dessus à cause de `alwaysOnTop: true`

## Fix

```typescript
invoke<boolean>("focus_window", { pid: session.pid })
  .then((focused) => {
    if (focused) {
      invoke("hide_window").catch(console.error);  // NEW
    } else {
      console.warn(...);
    }
  })
```

La commande Tauri `hide_window` existe déjà dans `src-tauri/src/lib.rs:47` (utilisée par le bouton minimize). Aucun nouveau code Rust requis.

## Comportement

- **Click sur card + focus réussit** → SynapseHub se masque, IDE visible. Re-ouvrir via tray icon.
- **Click sur card + focus échoue** (terminal fermé, process orphelin) → SynapseHub reste visible, `console.warn` explicite. L'utilisateur garde la visibilité du dashboard pour comprendre.

## Test plan

- [x] `cargo test --lib` → 43/43 passed
- [x] `npm test` → 7/7 passed
- [x] `npm run build` → frontend builds clean
- [x] `cargo check` → builds clean
- [ ] **Smoke test @thierry sur v0.1.5 build prod** :
  - Désinstaller v0.1.4 + installer v0.1.5
  - Lancer 2 sessions Claude Code Terminal
  - Cliquer la flèche d'une session → la dashboard doit **disparaître**, le terminal devient visible
  - Re-ouvrir SynapseHub via le tray icon → dashboard réapparaît
  - Tester pattern répétitif (3-5 cycles) pour vérifier le bug intermittent observé en v0.1.4 (1er click OK puis plus, après refresh DevTools rejoue) — si persiste, ouvrir issue v0.1.6

## Closes

- #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)