### PR TITLE
fix(focus): improve focus UX before v0.2.0 tag (4 bugs + 9 new tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-30
 
+### Fixed (pre-tag focus UX hardening)
+- **Click handler restreint au bouton focus** — la zone neutre des session cards (project name, path, IDE glyph, status pill) n'invoque plus rien au click. Avant le pre-tag fix, le listener était attaché à la fois à toute la `.session-card` ET au bouton focus, ce qui créait deux pièges UX révélés au smoke test v0.1.5 : (a) un click n'importe où sur la card déclenchait le flow focus + auto-hide, (b) le double listener pouvait fire en parallèle (bubble vs capture) et causait le bug intermittent "il faut le faire plusieurs fois". Le handler est maintenant uniquement sur `BUTTON[data-action="focus"]`. Le `keydown` Enter/Space reste sur la card pour préserver l'accessibilité clavier.
+- **alwaysOnTop dynamique au lieu de statique** — le flag dans `tauri.conf.json` est `false` par défaut. SynapseHub démarre comme une fenêtre normale qui peut passer en arrière-plan. Un toggle "Toujours au premier plan" dans le settings drawer permet d'activer le comportement HUD-overlay si l'utilisateur le souhaite. Préférence persistée dans `localStorage.synapsehub_always_on_top`. Avant, `alwaysOnTop: true` statique bloquait toutes les fenêtres tierces (y compris celles ramenées en Alt+Tab) — comportement invasif pour un companion tray tool.
+- **Action post-focus non destructive** — après un `focus_window === true`, on appelle désormais `set_always_on_top(false)` au lieu de `hide_window`. SynapseHub reste **visible** mais peut être recouverte par l'IDE, au lieu de disparaître complètement dans le tray. Récupération via Alt+Tab (workflow Windows natif) ou via le tray icon. Si le toggle utilisateur "Toujours au premier plan" est ON, la préférence est restaurée automatiquement quand SynapseHub regagne le focus (listener Tauri 2 `WebviewWindow::onFocusChanged`).
+- **Nouvelle commande Tauri `set_always_on_top(on_top: bool)`** dans `src-tauri/src/lib.rs`. Wrapper sur `WebviewWindow::set_always_on_top` avec `Result<(), String>` pour propagation propre des erreurs côté JS. Enregistrée dans `invoke_handler!`.
+
+### Refactor (pre-tag testability)
+- **`src/icons.ts` (nouveau)** — extraction des SVG builders (`svg`, `svgPath`, `svgCircle`, `svgLine`, `svgRect`, `buildBranchIcon`, `buildFocusIcon`, `buildCheckIcon`, `buildCopyIcon`, `buildBrandGlyph`) hors de `main.ts` pour réutilisation par `session-view.ts`. Zero `innerHTML`, security hook compliance préservée.
+- **`src/session-view.ts` augmenté** — nouveaux exports `renderSessionCard`, `attachFocusHandler`, `setAlwaysOnTopToggle`, `restoreAlwaysOnTopFromStorage`, `getAlwaysOnTopPreference`, `ALWAYS_ON_TOP_KEY`, type `InvokeFn`. Pattern dependency-injection sur la fonction `invoke` pour testabilité unitaire sans pull Tauri dans le test env.
+
 ### Changed
 - **UX/UI rework global** ([#30](https://github.com/thierryvm/SynapseHub/issues/30)) — refonte visuelle complète intégrée depuis le livrable Claude Design (claude.ai/design). Direction validée @thierry : Dark-first / hybride moderne / **cyan néon HUD subtil** (cohérent icône systray) / **Inter Display + JetBrains Mono Variable** / 4 piliers UX (adaptive density, responsive, settings drawer JSON, onboarding guide).
 - **Design tokens centralisés** dans `src/styles/tokens.css` (palette OKLCH dark + variant `[data-theme="light"]`, typographie, spacing 4px-base, radius, shadows, focus ring HUD, motion durations, layout, density modes). 9 fichiers de composants modulaires sous `src/styles/components/` (header, stats, toolbar, session-card, drawer, empty, onboarding, toast, footer).
@@ -34,10 +44,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ancien settings modal** — remplacé par le drawer slide-in.
 
 ### Tests
-- Tests Rust : 43/43 inchangés (régression-zéro sur watcher, focus, hooks).
-- Tests Vitest : 7/7 inchangés (`session-view.ts` augmenté avec `getStatusDataAttr`, `getStatusLabelShort`, `ideKey`, `ideGlyph` — les utilitaires legacy `summarizeSessions`, `getStatusKey`, etc. restent exportés pour la compat tests).
-- Build vite : 14 KB HTML, 35 KB CSS (7 KB gzip), 20 KB JS (7.2 KB gzip).
-- `cargo build --features debug-devtools` valide la feature flag opt-in.
+- Tests Rust : 43/43 inchangés (régression-zéro sur watcher, focus, hooks). `cargo clippy --all-features --all-targets -- -D warnings` clean. `cargo check --features debug-devtools` clean.
+- **Tests Vitest : 7/7 → 16/16**. 9 nouveaux tests DOM dans `src/session-view.dom.test.ts` (env jsdom) — couverture du gap d'interaction surfacé après le smoke v0.1.5 :
+  - `click on .card-focus button triggers focus_window invoke`
+  - `click on neutral card area does NOT trigger focus_window`
+  - `focus_window true triggers set_always_on_top(false)` (vérifie aussi qu'`hide_window` n'est PLUS appelé — régression-check vs v0.1.5)
+  - `focus_window false does NOT trigger set_always_on_top` + `console.warn` émis
+  - `Waiting status triggers acknowledge_waiting before focus`
+  - `toggle ON saves to localStorage and invokes set_always_on_top(true)`
+  - `toggle OFF saves to localStorage and invokes set_always_on_top(false)`
+  - `on app load, restores localStorage 'true' preference`
+  - `default is alwaysOnTop OFF when no localStorage value (no Rust call)`
+- Anciens tests `session-view.test.ts` (formatDuration, projectNameFromPath, sortSessions, summarizeSessions) restent en env node natif, untouched.
+- `jsdom` ajouté en `devDependencies` (devOnly, free, standard, supports `addEventListener` + `dispatchEvent` + `querySelector`).
+- Build vite : 15.7 KB HTML / 35 KB CSS (7 KB gzip) / 34.4 KB JS (10.4 KB gzip — augmente vs v0.2.0 PR #31 dû à l'import `@tauri-apps/api/window` pour le listener `onFocusChanged`).
+
+### Documentation
+- Note d'investigation `analysis/2026-04-30-focus-ux-investigation.md` documente la confirmation des 4 hypothèses de bugs UX dans le code post-PR #31, le plan de fix retenu (Option A complète du handoff §5), et les risques identifiés (loop focus-changed, localStorage indispo, refactor renderSessionCard, jsdom CSS limitations).
 
 ## [0.1.4] - 2026-04-30
 

--- a/analysis/2026-04-30-focus-ux-investigation.md
+++ b/analysis/2026-04-30-focus-ux-investigation.md
@@ -1,0 +1,128 @@
+# Focus UX investigation — pre-tag v0.2.0
+
+> **Date** : 2026-04-30
+> **Sprint** : v0.2.0 fix focus UX before tag (handoff `2026-04-30-1530-v0-2-0-fix-focus-ux-before-tag.md`)
+> **Trigger** : @thierry smoke test of v0.1.5 surfaced 4 UX bugs that propagate into the merged v0.2.0 (PR #31)
+> **Decision** : Voie 1 — fix on `main` before tagging v0.2.0, ship clean
+
+## Confirmation des 4 hypothèses
+
+| # | Bug observé | Cause primaire | Localisation exacte |
+|---|-------------|----------------|---------------------|
+| 1 | Click flèche intermittent | Double-fire `card` + `focusBtn` (event bubble + dual listener) | `src/main.ts:282-283` |
+| 2 | Click zone neutre = même action | Listener attaché à TOUTE la `.session-card`, pas seulement au bouton | `src/main.ts:282-289` |
+| 3 | App entièrement réduite dans le tray | `hide_window` Rust appelle `win.hide()` qui cache complètement | `src-tauri/src/lib.rs:51-55` |
+| 4 | alwaysOnTop invasif | Valeur statique `true` dans la conf, pas de toggle runtime | `src-tauri/tauri.conf.json:24` |
+
+### Détail Bug 1 — intermittence
+
+Pattern observé : "il faut le faire plusieurs fois". Cause hautement probable :
+- Le user click sur le bouton `BUTTON.card-focus` (icône SVG flèche).
+- L'event listener du bouton fire → `handleAction(event)` → `event.stopPropagation()`.
+- MAIS le listener est aussi attaché à `.session-card` (le parent ARTICLE) qui reçoit l'event en phase de capture (avant le bouton). Selon l'ordre exact d'évaluation, le card listener peut fire AVANT que stopPropagation soit déclenché par le bouton.
+- Conséquence : double-invoke. La 2ème invoke `focus_window` peut arriver après que le 1er focus ait déjà déclenché `hide_window` et que le PID Windows Terminal soit changé/re-parenté. → focus_window retourne false, hide_window n'est pas appelé, mais hide_window initial l'a déjà été. → state bizarre.
+
+Le fix structurel (un seul listener sur le bouton) supprime mécaniquement le double-fire et donc le bug 1 par la même occasion.
+
+### Détail Bug 3 — `hide_window`
+
+```rust
+// lib.rs:50-55
+fn hide_window(app: AppHandle) {
+    if let Some(win) = app.get_webview_window("dashboard") {
+        let _ = win.hide();
+    }
+}
+```
+
+`win.hide()` en Tauri 2 = WebviewWindow::hide() = `ShowWindow(SW_HIDE)` sur Windows = la fenêtre disparaît complètement de l'écran ET de la barre des tâches (déjà cachée via `skipTaskbar: true`). Pour la rouvrir, il faut passer par le tray icon.
+
+Le user attend "laisser passer le terminal devant", pas "minimiser SynapseHub". On veut SynapseHub rester visible mais en arrière-plan z-order.
+
+### Détail Bug 4 — alwaysOnTop invasif
+
+```json
+// tauri.conf.json:24
+"alwaysOnTop": true
+```
+
+Avec `alwaysOnTop: true`, Windows place la fenêtre dans le `HWND_TOPMOST` group → bloque TOUTES les fenêtres tierces non-TOPMOST. Pour un companion tool, c'est trop agressif. Devrait être désactivable (toggle settings) et désactivé par défaut.
+
+### Pas de commande Rust `set_always_on_top`
+
+Audit du `invoke_handler!` macro (`lib.rs:256-263`) :
+```rust
+.invoke_handler(tauri::generate_handler![
+    get_sessions,
+    focus_window,
+    acknowledge_waiting,
+    hide_window,
+    quit_app,
+    get_config,
+])
+```
+
+Aucune commande pour piloter dynamiquement `alwaysOnTop`. À ajouter :
+```rust
+#[tauri::command]
+fn set_always_on_top(app: AppHandle, on_top: bool) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("dashboard") {
+        win.set_always_on_top(on_top).map_err(|e| e.to_string())
+    } else {
+        Err("dashboard window not found".to_string())
+    }
+}
+```
+
+Tauri 2 expose `WebviewWindow::set_always_on_top(bool)` natif (cf. `tauri::WebviewWindow`).
+
+## Plan de fix retenu (Option A — handoff §5)
+
+1. **Rust** (`lib.rs`) : ajouter `set_always_on_top` + register dans `invoke_handler!`. Garder `hide_window` (utilisé pour le bouton minimize header). Pas de suppression.
+2. **Config** (`tauri.conf.json`) : `alwaysOnTop: true` → `false`. La fenêtre démarre normale.
+3. **Frontend session-view.ts** : refactor pour exposer `renderSessionCard(session)`, `attachFocusHandler(card, session, invokeFn)`, `setAlwaysOnTopToggle(on, invokeFn)`, `restoreAlwaysOnTopFromStorage(invokeFn)` — DI sur `invoke` pour testabilité.
+4. **Frontend main.ts** : utilise les nouveaux exports. Restaure la préférence localStorage au boot. Listener `onFocusChanged` qui re-applique alwaysOnTop=true uniquement si toggle utilisateur ON.
+5. **HTML drawer** : ajouter une `setting-row` avec toggle "Toujours au premier plan", default OFF.
+6. **Click handler** : restreint au bouton `BUTTON[data-action="focus"]`. Plus de listener sur la card entière. Le keydown reste sur card pour accessibilité (Enter/Space).
+7. **Action post-focus** : `invoke("hide_window")` → `invoke("set_always_on_top", { onTop: false })`. SynapseHub reste visible mais peut être recouverte.
+8. **Diagnostic** : `console.warn` si `focus_window` retourne false (déjà présent en v0.2.0 ; on garde).
+
+## Tests Vitest (handoff §6.bis)
+
+Ajout d'un nouveau fichier `src/session-view.dom.test.ts` (env jsdom) avec 9 tests :
+- 5 focus interaction (button click vs neutral zone, focus true/false branches, Waiting acknowledgement)
+- 4 alwaysOnTop toggle (set ON, set OFF, restore from localStorage, default OFF)
+
+Cible : vitest 7/7 → 16/16.
+
+L'ancien `session-view.test.ts` (7 tests, pure utility) garde son env node natif.
+
+Une `devDependency` `jsdom` sera ajoutée pour le nouveau fichier — devOnly, free, standard.
+
+## Fichiers impactés
+
+| Fichier | Type | Diff estimé |
+|--------|------|-------------|
+| `src-tauri/src/lib.rs` | modif | +12 lignes (commande + register) |
+| `src-tauri/tauri.conf.json` | modif | -1 / +1 |
+| `src/session-view.ts` | refactor | +180 lignes (move renderSessionCard + helpers + new exports) |
+| `src/main.ts` | refactor | -150 / +30 (delegate to session-view, add focus-changed listener + toggle handler) |
+| `index.html` | modif | +12 lignes (setting-row toggle dans drawer) |
+| `src/session-view.dom.test.ts` | nouveau | +180 lignes (9 tests) |
+| `package.json` | modif | +1 devDep `jsdom` |
+| `analysis/2026-04-30-focus-ux-investigation.md` | nouveau | ce fichier |
+
+## Risques / pièges identifiés
+
+1. **focus-changed listener loop** : si on re-active alwaysOnTop sur focus-gained, et que ça relance un événement focus, attention au loop. → Tester avec un guard explicit (set_always_on_top n'émet pas un focus-gained).
+2. **localStorage indispo** (sandbox tests) : wrapper try/catch autour de chaque accès, comme on a déjà fait pour le flag onboarding.
+3. **Refactor renderSessionCard** : doit garder le même DOM output pour ne pas casser la régression visuelle v0.2.0.
+4. **jsdom CSS limitations** : pas de layout calculé, pas de animations. Les tests d'interaction restent OK (pas de visual regression dans cette suite).
+
+## Validation
+
+- ✅ Ces 4 hypothèses confirmées dans le code actuel sur main (post-PR #31).
+- ✅ Plan de fix cohérent avec la stratégie handoff §5 (Option A complète).
+- ✅ Pas de scope creep (trio integration / folder watcher / webhook generic = v0.3.0+).
+
+Ready to attack Phase 3.

--- a/index.html
+++ b/index.html
@@ -141,8 +141,8 @@
               <div class="step-row">
                 <span class="step-num">3</span>
                 <div>
-                  <p class="step-title">Cliquez une carte pour focus</p>
-                  <p class="step-desc">SynapseHub se cache automatiquement.</p>
+                  <p class="step-title">Cliquez la flèche d'une carte</p>
+                  <p class="step-desc">Focus l'IDE, garde SynapseHub visible derrière.</p>
                 </div>
               </div>
             </div>
@@ -189,6 +189,23 @@
       </header>
 
       <div class="drawer-body">
+        <section class="setting-group">
+          <h3 class="setting-group-title">Comportement de la fenêtre</h3>
+          <div class="setting-row">
+            <span class="setting-label">Toujours au premier plan</span>
+            <button
+              class="toggle"
+              id="btn-toggle-always-on-top"
+              type="button"
+              aria-pressed="false"
+              aria-label="Activer ou désactiver le mode toujours au premier plan"
+            ></button>
+            <p class="setting-help">
+              Garde SynapseHub par-dessus toutes les autres fenêtres. Désactivé par défaut pour ne pas bloquer le focus de l'IDE après un click flèche.
+            </p>
+          </div>
+        </section>
+
         <section class="setting-group">
           <h3 class="setting-group-title">Hook Claude Code</h3>
           <p class="setting-help">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synapsehub",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synapsehub",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",
         "@tauri-apps/plugin-notification": "^2.2.1",
@@ -14,10 +14,215 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.5.0",
+        "jsdom": "^29.1.1",
         "sharp": "^0.33.5",
         "typescript": "^5.7.2",
         "vite": "^6.2.0",
         "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -471,6 +676,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1605,6 +1828,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1687,6 +1920,34 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1704,6 +1965,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -1723,6 +1991,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1827,10 +2108,30 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1841,12 +2142,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1857,6 +2209,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1882,6 +2241,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1950,6 +2322,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
@@ -1993,6 +2385,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.0",
         "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -2102,6 +2507,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2163,6 +2575,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2183,6 +2641,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -2356,6 +2824,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2372,6 +2888,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.5.0",
+    "jsdom": "^29.1.1",
     "sharp": "^0.33.5",
     "typescript": "^5.7.2",
     "vite": "^6.2.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,19 @@ fn hide_window(app: AppHandle) {
     }
 }
 
+/// Toggles the dashboard's `alwaysOnTop` flag at runtime. Driven by the user
+/// toggle in the settings drawer and by the focus action (which temporarily
+/// disables alwaysOnTop so the IDE window can come to the foreground without
+/// being covered by SynapseHub). Returns the standard string error so the
+/// frontend can log it.
+#[tauri::command]
+fn set_always_on_top(app: AppHandle, on_top: bool) -> Result<(), String> {
+    let win = app
+        .get_webview_window("dashboard")
+        .ok_or_else(|| "dashboard window not found".to_string())?;
+    win.set_always_on_top(on_top).map_err(|e| e.to_string())
+}
+
 /// Quits the application entirely.
 #[tauri::command]
 fn quit_app(app: AppHandle) {
@@ -258,6 +271,7 @@ pub fn run() {
             focus_window,
             acknowledge_waiting,
             hide_window,
+            set_always_on_top,
             quit_app,
             get_config,
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "visible": false,
         "decorations": false,
         "transparent": true,
-        "alwaysOnTop": true,
+        "alwaysOnTop": false,
         "skipTaskbar": true,
         "resizable": true,
         "shadow": true,

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,165 @@
+/**
+ * Inline SVG builders, all created via `document.createElementNS` so we never
+ * rely on `innerHTML` (security hook compliance, see `.claude/hooks/`).
+ *
+ * The functions return fresh DOM nodes; callers append them where needed and
+ * are free to set additional attributes (`width`, `height`, `class`, etc.)
+ * after the fact.
+ */
+
+export const SVG_NS = "http://www.w3.org/2000/svg";
+
+export function svg(
+  viewBox: string,
+  attrs: Record<string, string> = {},
+): SVGSVGElement {
+  const el = document.createElementNS(SVG_NS, "svg");
+  el.setAttribute("viewBox", viewBox);
+  el.setAttribute("aria-hidden", "true");
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  return el;
+}
+
+export function svgPath(
+  parent: SVGElement,
+  d: string,
+  attrs: Record<string, string> = {},
+): void {
+  const p = document.createElementNS(SVG_NS, "path");
+  p.setAttribute("d", d);
+  for (const [k, v] of Object.entries(attrs)) p.setAttribute(k, v);
+  parent.appendChild(p);
+}
+
+export function svgCircle(
+  parent: SVGElement,
+  cx: number,
+  cy: number,
+  r: number,
+  attrs: Record<string, string> = {},
+): void {
+  const c = document.createElementNS(SVG_NS, "circle");
+  c.setAttribute("cx", String(cx));
+  c.setAttribute("cy", String(cy));
+  c.setAttribute("r", String(r));
+  for (const [k, v] of Object.entries(attrs)) c.setAttribute(k, v);
+  parent.appendChild(c);
+}
+
+export function svgLine(
+  parent: SVGElement,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  attrs: Record<string, string> = {},
+): void {
+  const l = document.createElementNS(SVG_NS, "line");
+  l.setAttribute("x1", String(x1));
+  l.setAttribute("y1", String(y1));
+  l.setAttribute("x2", String(x2));
+  l.setAttribute("y2", String(y2));
+  for (const [k, v] of Object.entries(attrs)) l.setAttribute(k, v);
+  parent.appendChild(l);
+}
+
+export function svgRect(
+  parent: SVGElement,
+  attrs: Record<string, string>,
+): void {
+  const r = document.createElementNS(SVG_NS, "rect");
+  for (const [k, v] of Object.entries(attrs)) r.setAttribute(k, v);
+  parent.appendChild(r);
+}
+
+// ─── Domain icons ───────────────────────────────────────────────────────────
+
+export function buildBranchIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.4",
+    "stroke-linecap": "round",
+  });
+  svgCircle(s, 4, 3, 1.6);
+  svgCircle(s, 4, 13, 1.6);
+  svgCircle(s, 12, 6, 1.6);
+  svgPath(s, "M4 4.6v6.8");
+  svgPath(s, "M4 7.5c0-1.5 1-2.5 2.5-2.5h2.5");
+  return s;
+}
+
+export function buildFocusIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.4",
+    "stroke-linecap": "round",
+  });
+  svgPath(s, "M2 5V3a1 1 0 0 1 1-1h2");
+  svgPath(s, "M14 5V3a1 1 0 0 0-1-1h-2");
+  svgPath(s, "M2 11v2a1 1 0 0 0 1 1h2");
+  svgPath(s, "M14 11v2a1 1 0 0 1-1 1h-2");
+  svgCircle(s, 8, 8, 2);
+  return s;
+}
+
+export function buildCheckIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.6",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  });
+  svgPath(s, "M3 8.5l3 3 7-7");
+  return s;
+}
+
+export function buildCopyIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.4",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  });
+  svgPath(s, "M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2");
+  svgRect(s, { x: "5", y: "5", width: "9", height: "9", rx: "1.2" });
+  return s;
+}
+
+export function buildBrandGlyph(): SVGSVGElement {
+  const s = svg("0 0 32 32", { fill: "none", xmlns: SVG_NS });
+  svgCircle(s, 16, 16, 3.2, { fill: "currentColor" });
+  svgCircle(s, 16, 16, 6, {
+    stroke: "currentColor",
+    "stroke-width": "1.2",
+    "stroke-opacity": "0.5",
+  });
+  svgLine(s, 16, 16, 5, 5, {
+    stroke: "currentColor",
+    "stroke-width": "1.6",
+    "stroke-linecap": "round",
+  });
+  svgLine(s, 16, 16, 27, 5, {
+    stroke: "currentColor",
+    "stroke-width": "1.6",
+    "stroke-linecap": "round",
+  });
+  svgLine(s, 16, 16, 5, 27, {
+    stroke: "currentColor",
+    "stroke-width": "1.6",
+    "stroke-linecap": "round",
+  });
+  svgLine(s, 16, 16, 27, 27, {
+    stroke: "currentColor",
+    "stroke-width": "1.6",
+    "stroke-linecap": "round",
+  });
+  svgCircle(s, 5, 5, 2, { fill: "currentColor" });
+  svgCircle(s, 27, 5, 2, { fill: "currentColor" });
+  svgCircle(s, 5, 27, 2, { fill: "currentColor" });
+  svgCircle(s, 27, 27, 2, { fill: "currentColor" });
+  return s;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,19 @@
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { check, type Update } from "@tauri-apps/plugin-updater";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import packageJson from "../package.json";
 import {
   type AgentSession,
-  formatDuration,
-  getStatusDataAttr,
-  getStatusLabelShort,
-  ideGlyph,
-  ideKey,
-  projectNameFromPath,
+  ALWAYS_ON_TOP_KEY,
+  attachFocusHandler,
+  getAlwaysOnTopPreference,
+  renderSessionCard,
+  restoreAlwaysOnTopFromStorage,
+  setAlwaysOnTopToggle,
   sortSessions,
 } from "./session-view";
+import { buildBrandGlyph, buildCheckIcon, buildCopyIcon } from "./icons";
 
 // State
 let sessions: AgentSession[] = [];
@@ -23,7 +25,6 @@ let isInstallingUpdate = false;
 const APP_VERSION_LABEL = `v${packageJson.version}`;
 const ONBOARDING_FLAG = "synapsehub_onboarding_completed_v0.2.0";
 const DENSITY_COMPACT_THRESHOLD = 10;
-const SVG_NS = "http://www.w3.org/2000/svg";
 
 // DOM refs
 const root = document.documentElement;
@@ -52,6 +53,7 @@ const btnCloseDrawer = document.getElementById("btn-close-drawer") as HTMLButton
 const btnCopyConfig = document.getElementById("btn-copy-config") as HTMLButtonElement;
 const configCode = document.getElementById("config-code") as HTMLElement;
 const modalStatus = document.getElementById("modal-status") as HTMLElement;
+const btnToggleAlwaysOnTop = document.getElementById("btn-toggle-always-on-top") as HTMLButtonElement;
 
 const updateSummary = document.getElementById("update-summary") as HTMLElement;
 const updateMeta = document.getElementById("update-meta") as HTMLElement;
@@ -72,224 +74,7 @@ const btnOnboardNext = document.getElementById("onboard-next") as HTMLButtonElem
 
 versionLabel.textContent = APP_VERSION_LABEL;
 
-// SVG builders (no innerHTML)
-function svg(viewBox: string, attrs: Record<string, string> = {}): SVGSVGElement {
-  const el = document.createElementNS(SVG_NS, "svg");
-  el.setAttribute("viewBox", viewBox);
-  el.setAttribute("aria-hidden", "true");
-  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
-  return el;
-}
-
-function svgPath(parent: SVGElement, d: string, attrs: Record<string, string> = {}): void {
-  const p = document.createElementNS(SVG_NS, "path");
-  p.setAttribute("d", d);
-  for (const [k, v] of Object.entries(attrs)) p.setAttribute(k, v);
-  parent.appendChild(p);
-}
-
-function svgCircle(parent: SVGElement, cx: number, cy: number, r: number, attrs: Record<string, string> = {}): void {
-  const c = document.createElementNS(SVG_NS, "circle");
-  c.setAttribute("cx", String(cx));
-  c.setAttribute("cy", String(cy));
-  c.setAttribute("r", String(r));
-  for (const [k, v] of Object.entries(attrs)) c.setAttribute(k, v);
-  parent.appendChild(c);
-}
-
-function svgLine(parent: SVGElement, x1: number, y1: number, x2: number, y2: number, attrs: Record<string, string> = {}): void {
-  const l = document.createElementNS(SVG_NS, "line");
-  l.setAttribute("x1", String(x1));
-  l.setAttribute("y1", String(y1));
-  l.setAttribute("x2", String(x2));
-  l.setAttribute("y2", String(y2));
-  for (const [k, v] of Object.entries(attrs)) l.setAttribute(k, v);
-  parent.appendChild(l);
-}
-
-function buildBranchIcon(): SVGSVGElement {
-  const s = svg("0 0 16 16", {
-    fill: "none",
-    stroke: "currentColor",
-    "stroke-width": "1.4",
-    "stroke-linecap": "round",
-  });
-  svgCircle(s, 4, 3, 1.6);
-  svgCircle(s, 4, 13, 1.6);
-  svgCircle(s, 12, 6, 1.6);
-  svgPath(s, "M4 4.6v6.8");
-  svgPath(s, "M4 7.5c0-1.5 1-2.5 2.5-2.5h2.5");
-  return s;
-}
-
-function buildFocusIcon(): SVGSVGElement {
-  const s = svg("0 0 16 16", {
-    fill: "none",
-    stroke: "currentColor",
-    "stroke-width": "1.4",
-    "stroke-linecap": "round",
-  });
-  svgPath(s, "M2 5V3a1 1 0 0 1 1-1h2");
-  svgPath(s, "M14 5V3a1 1 0 0 0-1-1h-2");
-  svgPath(s, "M2 11v2a1 1 0 0 0 1 1h2");
-  svgPath(s, "M14 11v2a1 1 0 0 1-1 1h-2");
-  svgCircle(s, 8, 8, 2);
-  return s;
-}
-
-function buildCheckIcon(): SVGSVGElement {
-  const s = svg("0 0 16 16", {
-    fill: "none",
-    stroke: "currentColor",
-    "stroke-width": "1.6",
-    "stroke-linecap": "round",
-    "stroke-linejoin": "round",
-  });
-  svgPath(s, "M3 8.5l3 3 7-7");
-  return s;
-}
-
-function buildBrandGlyph(): SVGSVGElement {
-  const s = svg("0 0 32 32", { fill: "none", xmlns: SVG_NS });
-  svgCircle(s, 16, 16, 3.2, { fill: "currentColor" });
-  svgCircle(s, 16, 16, 6, { stroke: "currentColor", "stroke-width": "1.2", "stroke-opacity": "0.5" });
-  svgLine(s, 16, 16, 5, 5, { stroke: "currentColor", "stroke-width": "1.6", "stroke-linecap": "round" });
-  svgLine(s, 16, 16, 27, 5, { stroke: "currentColor", "stroke-width": "1.6", "stroke-linecap": "round" });
-  svgLine(s, 16, 16, 5, 27, { stroke: "currentColor", "stroke-width": "1.6", "stroke-linecap": "round" });
-  svgLine(s, 16, 16, 27, 27, { stroke: "currentColor", "stroke-width": "1.6", "stroke-linecap": "round" });
-  svgCircle(s, 5, 5, 2, { fill: "currentColor" });
-  svgCircle(s, 27, 5, 2, { fill: "currentColor" });
-  svgCircle(s, 5, 27, 2, { fill: "currentColor" });
-  svgCircle(s, 27, 27, 2, { fill: "currentColor" });
-  return s;
-}
-
-// Card rendering (DOM API only — no innerHTML)
-function renderSessionCard(session: AgentSession): HTMLElement {
-  const status = getStatusDataAttr(session.status);
-  const statusLabel = getStatusLabelShort(session.status);
-  const projectLabel = session.project_name || projectNameFromPath(session.project_path);
-  const ideKeyTxt = ideKey(session.ide_name);
-  const canFocus = session.pid > 0;
-
-  const card = document.createElement("article");
-  card.className = "session-card";
-  card.dataset.status = status;
-  card.dataset.pid = String(session.pid);
-  card.tabIndex = 0;
-  card.setAttribute("aria-label", `${projectLabel} — ${statusLabel}`);
-
-  // IDE glyph slot
-  const ide = document.createElement("div");
-  ide.className = "session-ide";
-  ide.dataset.ide = ideKeyTxt;
-  ide.title = session.ide_name;
-  ide.textContent = ideGlyph(session.ide_name);
-  card.appendChild(ide);
-
-  // Body (project / path / ide name / branch)
-  const body = document.createElement("div");
-  body.className = "session-body";
-
-  const line1 = document.createElement("div");
-  line1.className = "session-line-1";
-  const project = document.createElement("span");
-  project.className = "session-project";
-  project.title = projectLabel;
-  project.textContent = projectLabel;
-  line1.appendChild(project);
-  if (session.git_branch) {
-    const branch = document.createElement("span");
-    branch.className = "session-branch";
-    branch.appendChild(buildBranchIcon());
-    const branchTxt = document.createElement("span");
-    branchTxt.className = "branch-text";
-    branchTxt.textContent = session.git_branch;
-    branch.appendChild(branchTxt);
-    line1.appendChild(branch);
-  }
-  body.appendChild(line1);
-
-  const line2 = document.createElement("div");
-  line2.className = "session-line-2";
-  const path = document.createElement("span");
-  path.className = "session-path";
-  path.title = session.project_path;
-  path.textContent = session.project_path;
-  line2.appendChild(path);
-  const ideName = document.createElement("span");
-  ideName.className = "session-ide-name";
-  ideName.textContent = session.ide_name;
-  line2.appendChild(ideName);
-  body.appendChild(line2);
-
-  card.appendChild(body);
-
-  // Status pill
-  const statusEl = document.createElement("div");
-  statusEl.className = "session-status";
-  statusEl.setAttribute("aria-label", `Statut ${statusLabel}`);
-  const dot = document.createElement("span");
-  dot.className = "dot";
-  statusEl.appendChild(dot);
-  const label = document.createElement("span");
-  label.className = "label";
-  label.textContent = statusLabel;
-  statusEl.appendChild(label);
-  if (session.status.type === "Running" || session.status.type === "Waiting") {
-    const runtime = document.createElement("span");
-    runtime.className = "session-runtime";
-    runtime.textContent = formatDuration(session.status.since_secs);
-    statusEl.appendChild(runtime);
-  }
-  card.appendChild(statusEl);
-
-  // Action: focus
-  const actions = document.createElement("div");
-  actions.className = "session-actions";
-  const focusBtn = document.createElement("button");
-  focusBtn.className = "icon-btn";
-  focusBtn.type = "button";
-  focusBtn.dataset.action = "focus";
-  focusBtn.setAttribute("aria-label", "Focus IDE");
-  focusBtn.title = "Mettre la fenêtre IDE au premier plan";
-  if (!canFocus) focusBtn.disabled = true;
-  focusBtn.appendChild(buildFocusIcon());
-  actions.appendChild(focusBtn);
-  card.appendChild(actions);
-
-  // Click handlers (event capture pattern from v0.1.5)
-  const handleAction = (event: Event) => {
-    event.stopPropagation();
-    if (status === "waiting") {
-      invoke("acknowledge_waiting", { projectPath: session.project_path }).catch(console.error);
-    }
-    if (!canFocus) return;
-    invoke<boolean>("focus_window", { pid: session.pid })
-      .then((focused) => {
-        if (focused) {
-          // v0.1.5: dashboard is alwaysOnTop, hide it so the IDE actually shows.
-          invoke("hide_window").catch(console.error);
-        } else {
-          console.warn(
-            `focus_window(${session.pid}) → no window found in parent chain (terminal may have closed)`,
-          );
-        }
-      })
-      .catch((err) => console.error(`focus_window(${session.pid}) failed:`, err));
-  };
-
-  card.addEventListener("click", handleAction);
-  focusBtn.addEventListener("click", handleAction);
-  card.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      handleAction(event);
-    }
-  });
-
-  return card;
-}
+// ─── Stats / footer / density ───────────────────────────────────────────────
 
 function updateStats(): void {
   const active = sessions.filter((s) => s.status.type !== "Idle");
@@ -338,7 +123,11 @@ function render(): void {
   existingCards.forEach((c) => c.remove());
 
   if (!isEmpty) {
-    for (const s of sorted) sessionList.appendChild(renderSessionCard(s));
+    for (const s of sorted) {
+      const card = renderSessionCard(s);
+      attachFocusHandler(card, s, invoke);
+      sessionList.appendChild(card);
+    }
   }
 
   updateStats();
@@ -348,7 +137,8 @@ function render(): void {
       : "SynapseHub";
 }
 
-// Settings drawer
+// ─── Settings drawer ────────────────────────────────────────────────────────
+
 const TK_PATTERN =
   /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|[{}\[\],])/g;
 
@@ -366,7 +156,6 @@ function tokenClass(match: string): string {
  * the gaps between tokens are preserved as plain text nodes.
  */
 function highlightJSONIntoElement(target: HTMLElement, raw: string): void {
-  // Clear previous content
   while (target.firstChild) target.removeChild(target.firstChild);
 
   let lastIndex = 0;
@@ -420,10 +209,17 @@ async function loadConfig(): Promise<void> {
   }
 }
 
+function syncAlwaysOnTopButton(): void {
+  if (!btnToggleAlwaysOnTop) return;
+  const on = getAlwaysOnTopPreference();
+  btnToggleAlwaysOnTop.setAttribute("aria-pressed", String(on));
+}
+
 function openDrawer(): void {
   drawer.dataset.open = "true";
   drawer.setAttribute("aria-hidden", "false");
   drawerBackdrop.dataset.open = "true";
+  syncAlwaysOnTopButton();
   void loadConfig();
   void checkForUpdates(false);
 }
@@ -441,6 +237,14 @@ document.addEventListener("keydown", (event) => {
   if (event.key === "Escape" && drawer.dataset.open === "true") closeDrawer();
 });
 
+if (btnToggleAlwaysOnTop) {
+  btnToggleAlwaysOnTop.addEventListener("click", () => {
+    const next = btnToggleAlwaysOnTop.getAttribute("aria-pressed") !== "true";
+    btnToggleAlwaysOnTop.setAttribute("aria-pressed", String(next));
+    setAlwaysOnTopToggle(next, invoke);
+  });
+}
+
 btnCopyConfig.addEventListener("click", async () => {
   const raw = configCode.dataset.raw ?? configCode.textContent ?? "";
   try {
@@ -455,26 +259,8 @@ btnCopyConfig.addEventListener("click", async () => {
     setTimeout(() => {
       btnCopyConfig.removeAttribute("data-state");
       while (btnCopyConfig.firstChild) btnCopyConfig.removeChild(btnCopyConfig.firstChild);
-      // Restore the original SVG + label
-      const s = svg("0 0 16 16", {
-        fill: "none",
-        stroke: "currentColor",
-        "stroke-width": "1.4",
-        "stroke-linecap": "round",
-        "stroke-linejoin": "round",
-      });
-      svgPath(s, "M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2");
-      // Inner rect via path is awkward — use rect element instead.
-      const rect = document.createElementNS(SVG_NS, "rect");
-      rect.setAttribute("x", "5");
-      rect.setAttribute("y", "5");
-      rect.setAttribute("width", "9");
-      rect.setAttribute("height", "9");
-      rect.setAttribute("rx", "1.2");
-      s.appendChild(rect);
-      btnCopyConfig.appendChild(s);
+      btnCopyConfig.appendChild(buildCopyIcon());
       btnCopyConfig.appendChild(document.createTextNode(" Copier"));
-
       if (modalStatus.textContent === "Configuration copiée") modalStatus.textContent = "";
     }, 1800);
   } catch {
@@ -482,7 +268,8 @@ btnCopyConfig.addEventListener("click", async () => {
   }
 });
 
-// Updates
+// ─── Updates ────────────────────────────────────────────────────────────────
+
 function setUpdateControls(): void {
   btnCheckUpdates.disabled = isCheckingUpdates || isInstallingUpdate;
   btnInstallUpdate.disabled = !availableUpdate || isCheckingUpdates || isInstallingUpdate;
@@ -614,7 +401,8 @@ function formatBytes(bytes: number): string {
 btnCheckUpdates.addEventListener("click", () => void checkForUpdates(true));
 btnInstallUpdate.addEventListener("click", () => void installUpdate());
 
-// Onboarding (3 slides, persisted in localStorage)
+// ─── Onboarding (3 slides, persisted in localStorage) ─────────────────
+
 interface OnboardSlide {
   eyebrow: string;
   title: string;
@@ -642,7 +430,9 @@ const ONBOARD_SLIDES: OnboardSlide[] = [
     eyebrow: "Étape 3 / 3 — Focus",
     title: "Une carte = un saut vers l'IDE",
     bodyLines: [
-      "Cliquez sur une session pour amener la fenêtre Windows Terminal / IDE au premier plan. SynapseHub se cache automatiquement après le focus.",
+      "Cliquez sur le bouton flèche d'une session pour amener la fenêtre Windows Terminal / IDE au premier plan. Le bouton ",
+      { code: "Toujours au premier plan" },
+      " des paramètres garde SynapseHub par-dessus si vous le souhaitez.",
     ],
   },
 ];
@@ -716,7 +506,8 @@ btnOnboardNext.addEventListener("click", () => {
 
 btnShowOnboarding.addEventListener("click", openOnboarding);
 
-// Window controls
+// ─── Window controls ────────────────────────────────────────────────────────
+
 btnMinimize.addEventListener("click", () => {
   invoke("hide_window").catch(console.error);
 });
@@ -725,14 +516,44 @@ btnClose.addEventListener("click", () => {
   invoke("quit_app").catch(console.error);
 });
 
-// Tauri events
+// ─── Tauri events ───────────────────────────────────────────────────────────
+
 listen<AgentSession[]>("agents-updated", (event) => {
   sessions = event.payload;
   render();
 });
 
-// Init
+/**
+ * Re-applies the persisted alwaysOnTop preference whenever the dashboard
+ * regains focus. The focus action temporarily disables alwaysOnTop so the
+ * IDE window can come to the foreground; once the user comes back to
+ * SynapseHub (tray click, Alt+Tab, etc.) we honour their toggle preference
+ * again.
+ */
+async function setupFocusListener(): Promise<void> {
+  try {
+    const win = getCurrentWindow();
+    await win.onFocusChanged(({ payload: focused }) => {
+      if (focused && getAlwaysOnTopPreference()) {
+        invoke("set_always_on_top", { onTop: true }).catch((err) =>
+          console.error("set_always_on_top(true) on focus failed:", err),
+        );
+      }
+    });
+  } catch (err) {
+    console.error("Failed to wire onFocusChanged listener:", err);
+  }
+}
+
+// ─── Init ───────────────────────────────────────────────────────────────────
+
 async function init(): Promise<void> {
+  // Restore the user's alwaysOnTop preference (handoff §5 — Fix 3).
+  // Default OFF; only invokes Rust when the user explicitly enabled it.
+  restoreAlwaysOnTopFromStorage(invoke);
+  syncAlwaysOnTopButton();
+  void setupFocusListener();
+
   try {
     sessions = await invoke<AgentSession[]>("get_sessions");
   } catch (err) {
@@ -751,3 +572,7 @@ async function init(): Promise<void> {
 }
 
 void init();
+
+// Re-export the storage key so callers (and tests) can clear the toggle
+// without hard-coding the literal.
+export { ALWAYS_ON_TOP_KEY };

--- a/src/session-view.dom.test.ts
+++ b/src/session-view.dom.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * DOM-level interaction tests for session-view.ts. These complement the
+ * pure-utility tests in session-view.test.ts (which run in node) and cover
+ * the regressions surfaced during the v0.1.5 → v0.2.0 smoke tests:
+ *
+ * - Click on the focus button must invoke `focus_window`
+ * - Click on the rest of the card must NOT invoke anything
+ * - Successful focus must invoke `set_always_on_top(false)` (NOT
+ *   `hide_window` like v0.1.5 used to do)
+ * - Failed focus must NOT invoke `set_always_on_top`
+ * - Waiting status acknowledges before focusing
+ *
+ * Plus the alwaysOnTop toggle helpers (set / restore / default).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  ALWAYS_ON_TOP_KEY,
+  attachFocusHandler,
+  renderSessionCard,
+  restoreAlwaysOnTopFromStorage,
+  setAlwaysOnTopToggle,
+  type AgentSession,
+} from "./session-view";
+
+function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    pid: 4242,
+    project_name: "SynapseHub",
+    project_path: "F:/PROJECTS/Apps/SynapseHub",
+    ide_name: "Claude Code Terminal",
+    git_branch: "main",
+    status: { type: "Running", since_secs: 120 },
+    lock_file: "process_F:/PROJECTS/Apps/SynapseHub",
+    ...overrides,
+  };
+}
+
+/**
+ * Waits for any microtasks (`Promise.resolve().then(...)`) queued during a
+ * click handler to flush before assertions run. Two `await Promise.resolve()`
+ * cover the chained `.then(...)` of `focus_window` → `set_always_on_top`.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Session card focus interaction", () => {
+  test("click on .card-focus button triggers focus_window invoke", async () => {
+    const invokeMock = vi.fn().mockResolvedValue(true);
+    const session = makeSession();
+    const card = renderSessionCard(session);
+    attachFocusHandler(card, session, invokeMock);
+
+    const focusBtn = card.querySelector<HTMLButtonElement>('button[data-action="focus"]');
+    expect(focusBtn).not.toBeNull();
+    focusBtn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await flushMicrotasks();
+
+    const focusCall = invokeMock.mock.calls.find((call) => call[0] === "focus_window");
+    expect(focusCall).toBeDefined();
+    expect(focusCall?.[1]).toEqual({ pid: session.pid });
+  });
+
+  test("click on neutral card area does NOT trigger focus_window", async () => {
+    const invokeMock = vi.fn();
+    const session = makeSession();
+    const card = renderSessionCard(session);
+    attachFocusHandler(card, session, invokeMock);
+
+    // Click on the project label area (neutral zone, NOT inside the focus button)
+    const project = card.querySelector(".session-project");
+    expect(project).not.toBeNull();
+    project?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    // Click on the IDE glyph slot
+    const ide = card.querySelector(".session-ide");
+    expect(ide).not.toBeNull();
+    ide?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    // Click on the card itself
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await flushMicrotasks();
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  test("focus_window true triggers set_always_on_top(false)", async () => {
+    const invokeMock = vi
+      .fn()
+      .mockImplementation((cmd: string) =>
+        cmd === "focus_window" ? Promise.resolve(true) : Promise.resolve(undefined),
+      );
+    const session = makeSession();
+    const card = renderSessionCard(session);
+    attachFocusHandler(card, session, invokeMock);
+
+    card
+      .querySelector<HTMLButtonElement>('button[data-action="focus"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await flushMicrotasks();
+
+    expect(invokeMock).toHaveBeenCalledWith("focus_window", { pid: session.pid });
+    expect(invokeMock).toHaveBeenCalledWith("set_always_on_top", { onTop: false });
+    // hide_window should NOT be called (regression check vs v0.1.5)
+    expect(invokeMock).not.toHaveBeenCalledWith("hide_window", expect.anything());
+  });
+
+  test("focus_window false does NOT trigger set_always_on_top", async () => {
+    const invokeMock = vi
+      .fn()
+      .mockImplementation((cmd: string) =>
+        cmd === "focus_window" ? Promise.resolve(false) : Promise.resolve(undefined),
+      );
+    const session = makeSession();
+    const card = renderSessionCard(session);
+    attachFocusHandler(card, session, invokeMock);
+
+    // Silence the expected console.warn so the test output stays clean.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    card
+      .querySelector<HTMLButtonElement>('button[data-action="focus"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await flushMicrotasks();
+
+    expect(invokeMock).toHaveBeenCalledWith("focus_window", { pid: session.pid });
+    expect(invokeMock).not.toHaveBeenCalledWith("set_always_on_top", expect.anything());
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  test("Waiting status triggers acknowledge_waiting before focus", async () => {
+    const invokeMock = vi
+      .fn()
+      .mockImplementation((cmd: string) =>
+        cmd === "focus_window" ? Promise.resolve(true) : Promise.resolve(undefined),
+      );
+    const session = makeSession({ status: { type: "Waiting", since_secs: 30 } });
+    const card = renderSessionCard(session);
+    attachFocusHandler(card, session, invokeMock);
+
+    card
+      .querySelector<HTMLButtonElement>('button[data-action="focus"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await flushMicrotasks();
+
+    const ackCall = invokeMock.mock.calls.findIndex((call) => call[0] === "acknowledge_waiting");
+    const focusCall = invokeMock.mock.calls.findIndex((call) => call[0] === "focus_window");
+
+    expect(ackCall).toBeGreaterThanOrEqual(0);
+    expect(focusCall).toBeGreaterThanOrEqual(0);
+    // Acknowledgement is fired first (synchronously) so the marker clears
+    // even if the focus path errors out.
+    expect(ackCall).toBeLessThan(focusCall);
+    expect(invokeMock).toHaveBeenCalledWith("acknowledge_waiting", { projectPath: session.project_path });
+  });
+});
+
+describe("AlwaysOnTop settings toggle", () => {
+  test("toggle ON saves to localStorage and invokes set_always_on_top(true)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+
+    setAlwaysOnTopToggle(true, invokeMock);
+
+    expect(localStorage.getItem(ALWAYS_ON_TOP_KEY)).toBe("true");
+    expect(invokeMock).toHaveBeenCalledWith("set_always_on_top", { onTop: true });
+  });
+
+  test("toggle OFF saves to localStorage and invokes set_always_on_top(false)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+    localStorage.setItem(ALWAYS_ON_TOP_KEY, "true");
+
+    setAlwaysOnTopToggle(false, invokeMock);
+
+    expect(localStorage.getItem(ALWAYS_ON_TOP_KEY)).toBe("false");
+    expect(invokeMock).toHaveBeenCalledWith("set_always_on_top", { onTop: false });
+  });
+
+  test("on app load, restores localStorage 'true' preference", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+    localStorage.setItem(ALWAYS_ON_TOP_KEY, "true");
+
+    restoreAlwaysOnTopFromStorage(invokeMock);
+
+    expect(invokeMock).toHaveBeenCalledWith("set_always_on_top", { onTop: true });
+  });
+
+  test("default is alwaysOnTop OFF when no localStorage value (no Rust call)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+
+    restoreAlwaysOnTopFromStorage(invokeMock);
+
+    // No invoke at all — the Tauri config already has alwaysOnTop=false,
+    // so restoring "default" is a no-op and we must not flap the flag.
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -1,3 +1,5 @@
+import { buildBranchIcon, buildFocusIcon } from "./icons";
+
 export type AgentStatus =
   | { type: "Running"; since_secs: number }
   | { type: "Waiting"; since_secs: number }
@@ -22,6 +24,19 @@ export interface SessionSummary {
   subtitle: string;
   footer: string;
 }
+
+/**
+ * Minimal contract the renderer needs from `@tauri-apps/api/core`. Defining
+ * it here lets us inject a mock in unit tests without pulling Tauri into
+ * the test environment.
+ */
+export type InvokeFn = <T = unknown>(
+  cmd: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+/** Persisted user preference for the "always on top" window flag. */
+export const ALWAYS_ON_TOP_KEY = "synapsehub_always_on_top";
 
 export function formatDuration(secs: number): string {
   if (secs < 60) return `${secs}s`;
@@ -195,4 +210,222 @@ const IDE_GLYPHS: Record<string, string> = {
 
 export function ideGlyph(ideName: string): string {
   return IDE_GLYPHS[ideKey(ideName)] ?? "··";
+}
+
+// ─── DOM rendering & interaction ────────────────────────────────────────────
+
+/**
+ * Builds the DOM tree for one session card. Returns a fresh `<article>` —
+ * **no event listeners attached**. Wire interactions via
+ * `attachFocusHandler` so the two concerns (markup vs. behaviour) stay
+ * independently testable.
+ */
+export function renderSessionCard(session: AgentSession): HTMLElement {
+  const status = getStatusDataAttr(session.status);
+  const statusLabel = getStatusLabelShort(session.status);
+  const projectLabel = session.project_name || projectNameFromPath(session.project_path);
+  const ideKeyTxt = ideKey(session.ide_name);
+  const canFocus = session.pid > 0;
+
+  const card = document.createElement("article");
+  card.className = "session-card";
+  card.dataset.status = status;
+  card.dataset.pid = String(session.pid);
+  card.tabIndex = 0;
+  card.setAttribute("aria-label", `${projectLabel} — ${statusLabel}`);
+
+  // IDE glyph slot
+  const ide = document.createElement("div");
+  ide.className = "session-ide";
+  ide.dataset.ide = ideKeyTxt;
+  ide.title = session.ide_name;
+  ide.textContent = ideGlyph(session.ide_name);
+  card.appendChild(ide);
+
+  // Body (project / path / ide name / branch)
+  const body = document.createElement("div");
+  body.className = "session-body";
+
+  const line1 = document.createElement("div");
+  line1.className = "session-line-1";
+  const project = document.createElement("span");
+  project.className = "session-project";
+  project.title = projectLabel;
+  project.textContent = projectLabel;
+  line1.appendChild(project);
+  if (session.git_branch) {
+    const branch = document.createElement("span");
+    branch.className = "session-branch";
+    branch.appendChild(buildBranchIcon());
+    const branchTxt = document.createElement("span");
+    branchTxt.className = "branch-text";
+    branchTxt.textContent = session.git_branch;
+    branch.appendChild(branchTxt);
+    line1.appendChild(branch);
+  }
+  body.appendChild(line1);
+
+  const line2 = document.createElement("div");
+  line2.className = "session-line-2";
+  const path = document.createElement("span");
+  path.className = "session-path";
+  path.title = session.project_path;
+  path.textContent = session.project_path;
+  line2.appendChild(path);
+  const ideName = document.createElement("span");
+  ideName.className = "session-ide-name";
+  ideName.textContent = session.ide_name;
+  line2.appendChild(ideName);
+  body.appendChild(line2);
+
+  card.appendChild(body);
+
+  // Status pill
+  const statusEl = document.createElement("div");
+  statusEl.className = "session-status";
+  statusEl.setAttribute("aria-label", `Statut ${statusLabel}`);
+  const dot = document.createElement("span");
+  dot.className = "dot";
+  statusEl.appendChild(dot);
+  const label = document.createElement("span");
+  label.className = "label";
+  label.textContent = statusLabel;
+  statusEl.appendChild(label);
+  if (session.status.type === "Running" || session.status.type === "Waiting") {
+    const runtime = document.createElement("span");
+    runtime.className = "session-runtime";
+    runtime.textContent = formatDuration(session.status.since_secs);
+    statusEl.appendChild(runtime);
+  }
+  card.appendChild(statusEl);
+
+  // Action: focus
+  const actions = document.createElement("div");
+  actions.className = "session-actions";
+  const focusBtn = document.createElement("button");
+  focusBtn.className = "icon-btn card-focus";
+  focusBtn.type = "button";
+  focusBtn.dataset.action = "focus";
+  focusBtn.setAttribute("aria-label", "Focus IDE");
+  focusBtn.title = "Mettre la fenêtre IDE au premier plan";
+  if (!canFocus) focusBtn.disabled = true;
+  focusBtn.appendChild(buildFocusIcon());
+  actions.appendChild(focusBtn);
+  card.appendChild(actions);
+
+  return card;
+}
+
+/**
+ * Wires the focus action on a previously rendered session card.
+ *
+ * Behaviour (matches v0.2.0 fix focus-UX, see handoff
+ * `2026-04-30-1530-v0-2-0-fix-focus-ux-before-tag.md` §5):
+ *
+ * 1. Click on `BUTTON[data-action="focus"]` (or Enter/Space when the card
+ *    has keyboard focus) only triggers the IDE focus flow. **A click on
+ *    the rest of the card body is intentionally a no-op** so the user
+ *    doesn't accidentally hide the dashboard while reading session info.
+ * 2. If the session is `Waiting`, an `acknowledge_waiting` invoke is fired
+ *    first so the waiting marker is cleared regardless of whether the
+ *    focus succeeds.
+ * 3. On `focus_window === true` we invoke `set_always_on_top(false)` so
+ *    the IDE window the user just asked for can come to the foreground
+ *    even when the user has the alwaysOnTop toggle ON. The
+ *    `onFocusChanged` listener in `main.ts` re-applies the toggle when
+ *    the dashboard regains focus.
+ * 4. On `focus_window === false` we keep the dashboard visible and emit a
+ *    `console.warn` so the user can tell the action did nothing (typical
+ *    when the terminal closed between detection and click).
+ */
+export function attachFocusHandler(
+  card: HTMLElement,
+  session: AgentSession,
+  invokeFn: InvokeFn,
+): void {
+  const focusBtn = card.querySelector<HTMLButtonElement>('button[data-action="focus"]');
+  if (!focusBtn) return;
+
+  const trigger = (event: Event) => {
+    event.stopPropagation();
+
+    if (session.status.type === "Waiting") {
+      void invokeFn("acknowledge_waiting", { projectPath: session.project_path }).catch(
+        (err) => console.error(`acknowledge_waiting(${session.project_path}) failed:`, err),
+      );
+    }
+
+    if (session.pid <= 0) return;
+
+    void invokeFn<boolean>("focus_window", { pid: session.pid })
+      .then((focused) => {
+        if (focused) {
+          // Temporarily release alwaysOnTop so the IDE window actually
+          // appears in front. The settings toggle (if user-enabled) is
+          // re-applied via the focus-changed listener in main.ts.
+          void invokeFn("set_always_on_top", { onTop: false }).catch((err) =>
+            console.error("set_always_on_top(false) failed:", err),
+          );
+        } else {
+          console.warn(
+            `focus_window(${session.pid}) → no window found in parent chain (terminal may have closed)`,
+          );
+        }
+      })
+      .catch((err) => console.error(`focus_window(${session.pid}) failed:`, err));
+  };
+
+  focusBtn.addEventListener("click", trigger);
+  card.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      trigger(event);
+    }
+  });
+}
+
+/**
+ * Persists the user preference and pushes it to the Rust side. Called from
+ * the settings drawer toggle.
+ */
+export function setAlwaysOnTopToggle(on: boolean, invokeFn: InvokeFn): void {
+  try {
+    localStorage.setItem(ALWAYS_ON_TOP_KEY, String(on));
+  } catch {
+    /* localStorage blocked — preference won't persist across launches but the
+       runtime call below still applies for the current session */
+  }
+  void invokeFn("set_always_on_top", { onTop: on }).catch((err) =>
+    console.error("set_always_on_top failed:", err),
+  );
+}
+
+/**
+ * Reads the persisted preference at app start and pushes it to Rust if (and
+ * only if) the user explicitly enabled it. Default = OFF (matches
+ * `tauri.conf.json` `alwaysOnTop: false`); we therefore skip the invoke when
+ * the value is missing or "false" to avoid touching the window state for a
+ * no-op.
+ */
+export function restoreAlwaysOnTopFromStorage(invokeFn: InvokeFn): void {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(ALWAYS_ON_TOP_KEY);
+  } catch {
+    return;
+  }
+  if (stored === "true") {
+    void invokeFn("set_always_on_top", { onTop: true }).catch((err) =>
+      console.error("set_always_on_top failed:", err),
+    );
+  }
+}
+
+/** Reads the current persisted preference. Returns `false` when missing. */
+export function getAlwaysOnTopPreference(): boolean {
+  try {
+    return localStorage.getItem(ALWAYS_ON_TOP_KEY) === "true";
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Pre-tag fix for v0.2.0. Resolves 4 UX bugs surfaced during the v0.1.5 smoke test by @thierry. **v0.2.0 will be tagged AFTER this PR is merged** so the first v0.2.0 release ships clean.

Refs handoff cowork-handoffs (Obsidian vault) `2026-04-30-1530-v0-2-0-fix-focus-ux-before-tag.md`.

## Bugs fixed

| # | Symptôme observé | Cause primaire | Fix |
|---|------------------|----------------|-----|
| 1 | Click flèche intermittent | Double-fire `card` + `focusBtn` (event bubble + dual listener) | Listener restreint à `BUTTON[data-action=\"focus\"]` |
| 2 | Click zone neutre = même action que flèche | Listener attaché à toute `.session-card` | Card listener supprimé (keydown reste pour a11y) |
| 3 | App entièrement réduite dans le tray | `hide_window` Rust appelle `win.hide()` | Replacé par `set_always_on_top(false)` |
| 4 | alwaysOnTop persistent et invasif | Valeur statique `true` dans la conf | Default `false` + toggle settings + listener focus-changed |

## Rust changes

- **New Tauri command** `set_always_on_top(on_top: bool)` in `src-tauri/src/lib.rs`. Wrapper sur `WebviewWindow::set_always_on_top`, retourne `Result<(), String>` pour propagation propre des erreurs côté JS. Registered in `invoke_handler!`.
- `src-tauri/tauri.conf.json` : `alwaysOnTop` `true` → `false`.

## Frontend changes

- **New `src/icons.ts` module** : SVG builders (`buildBranchIcon`, `buildFocusIcon`, `buildCheckIcon`, `buildCopyIcon`, `buildBrandGlyph`) extraits de `main.ts` pour réutilisation depuis `session-view.ts`. Zéro `innerHTML`, security hook compliance préservée.
- **`src/session-view.ts` augmenté** :
  - `renderSessionCard(session)` (move depuis `main.ts`) — DOM construction pure, sans event listeners
  - `attachFocusHandler(card, session, invokeFn)` — séparation des concerns, listener uniquement sur le bouton focus
  - `setAlwaysOnTopToggle(on, invokeFn)` — persiste localStorage + invoke Rust
  - `restoreAlwaysOnTopFromStorage(invokeFn)` — restaure préférence au boot, no-op si default OFF
  - `getAlwaysOnTopPreference()` — lecture pure de la préférence
  - `ALWAYS_ON_TOP_KEY` constant exportée
  - Type `InvokeFn` pour dependency-injection en tests
- **`src/main.ts` refactored** : delegate à `session-view.ts`, ajoute le toggle wiring + `WebviewWindow.onFocusChanged` listener qui re-applique la préférence quand SynapseHub regagne le focus.
- **`index.html`** : nouveau `setting-row` "Toujours au premier plan" dans le drawer settings (section \"Comportement de la fenêtre\"). Ajusté l'empty-state step 3 pour refléter le nouveau UX.

## Tests (handoff §6.bis — 9 nouveaux tests obligatoires)

- **Vitest 7/7 → 16/16** ✅
- New file `src/session-view.dom.test.ts` (env jsdom) :
  - **5 focus interaction tests**
    - `click on .card-focus button triggers focus_window invoke`
    - `click on neutral card area does NOT trigger focus_window`
    - `focus_window true triggers set_always_on_top(false)` (+ régression-check : `hide_window` NOT called)
    - `focus_window false does NOT trigger set_always_on_top` + `console.warn` émis
    - `Waiting status triggers acknowledge_waiting before focus`
  - **4 alwaysOnTop toggle tests**
    - `toggle ON saves to localStorage and invokes set_always_on_top(true)`
    - `toggle OFF saves to localStorage and invokes set_always_on_top(false)`
    - `on app load, restores localStorage 'true' preference`
    - `default is alwaysOnTop OFF when no localStorage value (no Rust call)`
- `jsdom` ajouté en `devDependencies` (devOnly, free, standard).
- Anciens tests `session-view.test.ts` (env node natif) restent verts.

## Validation locale

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --lib --all-features` 43/43
- [x] `cargo check --features debug-devtools` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 16/16
- [x] `npm run build` 15.7 KB HTML / 35 KB CSS / 34.4 KB JS (10.4 KB gzip)

## Validation post-merge avant tag v0.2.0

- [ ] CI green (Rust + Frontend)
- [ ] Sourcery silent
- [ ] @thierry smoke test rapide en build dev (`npm run tauri dev`) :
  - Click flèche → focus terminal + SynapseHub passe en arrière-plan (visible mais derrière)
  - Click zone neutre card → no-op (aucune action)
  - Settings drawer → toggle \"Toujours au premier plan\" OFF par défaut
  - Activer le toggle → SynapseHub passe par-dessus tout, désactiver → fenêtre normale
  - Test pattern répétitif (3-5 cycles) → comportement stable, pas d'intermittent
- [ ] Si OK → tag v0.2.0 sur le commit de merge

## Documentation

- `analysis/2026-04-30-focus-ux-investigation.md` documente la confirmation des 4 hypothèses dans le code post-PR #31, le plan de fix retenu, et les risques identifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)