### PR TITLE
feat(frame+settings): maximize button + keep-in-taskbar toggle (Vague 1 v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (v0.3.0 Vague 1 — #33 + #34)
+- **Frame: maximize/restore button** ([#33](https://github.com/thierryvm/SynapseHub/issues/33)) — bouton SVG inséré entre minimize et close. Icône swap automatique entre carré simple (état normal → "Agrandir") et double-carré chevauché (état maximisé → "Restaurer"). Sync via `WebviewWindow.onResized` listener pour rester aligné avec l'état réel même si l'utilisateur maximise via raccourci OS (Win+Up, drag-to-edge, double-click titlebar). Nouveaux helpers `buildMaximizeIcon` / `buildRestoreIcon` dans `src/icons.ts`, helper DI `setMaximizeButtonState(button, maximized)` dans `src/session-view.ts` (zero `innerHTML`).
+- **Settings: "Garder dans la barre des tâches" toggle (Option A)** ([#34](https://github.com/thierryvm/SynapseHub/issues/34)) — ajouté sous "Toujours au premier plan" dans le drawer settings. **OFF par défaut** : SynapseHub reste un compagnon tray invisible (comportement actuel préservé). **ON** : la fenêtre apparaît dans la barre des tâches Windows / Dock macOS, et le bouton réduire effectue un minimize OS classique au lieu d'envoyer dans le tray. Persistance `localStorage.synapsehub_keep_taskbar`. Helpers DI `setKeepTaskbarToggle`, `restoreKeepTaskbarFromStorage`, `getKeepTaskbarPreference`, constante `KEEP_TASKBAR_KEY` exportés depuis `src/session-view.ts` (pattern aligné sur `setAlwaysOnTopToggle`).
+- **Commande Tauri `toggle_maximize`** (`src-tauri/src/lib.rs`) — flippe entre maximisé et normal, retourne le nouvel état (`Result<bool, String>`) pour que le frontend swap l'icône sans poll séparé. Générique sur `R: Runtime` pour testabilité via `MockRuntime`.
+- **Commande Tauri `set_keep_taskbar(keep: bool)`** (`src-tauri/src/lib.rs`) — appelle `WebviewWindow::set_skip_taskbar(!keep)` ; sur macOS flippe aussi `app.set_activation_policy(Regular ↔ Accessory)` pour que le toggle soit visible (sans le 2ème op, `set_skip_taskbar(false)` seul est un no-op sur macOS car l'activation policy fixée en `setup` neutralise la visibilité). Générique sur `R: Runtime`.
+- **Commande Tauri `minimize_window`** (`src-tauri/src/lib.rs`) — minimize OS-natif, distinct de `hide_window` (qui envoie au tray). Utilisée quand l'utilisateur a activé "Garder dans la barre des tâches". Générique sur `R: Runtime`.
+
+### Changed
+- **Bouton minimize (`-`) respecte la nouvelle préférence "Garder dans la barre des tâches"** — preference OFF (défaut) : `hide_window` (tray, comportement v0.2.x préservé). Preference ON : `minimize_window` (minimize OS natif). La préférence est lue à chaque clic, donc le toggle prend effet immédiatement sans redémarrage. Logique dans `src/main.ts` ; choix arbitré Option β par @cowork (cohérence UX : si l'utilisateur a demandé la taskbar, il s'attend à un vrai minimize).
+
+### Tests (Vague 1)
+- **3 tests Rust err-only** dans `src-tauri/src/lib.rs` (module `vague_1_window_controls_mock_app`, gated `#[cfg(not(target_os = "windows"))]` — même contrainte que les helpers single-instance v0.2.1) : `minimize_window_errors_when_dashboard_window_absent`, `toggle_maximize_errors_when_dashboard_window_absent`, `set_keep_taskbar_errors_when_dashboard_window_absent`. Couvrent la branche `dashboard window not found` ; le happy path dépend de `WebviewWindow::{minimize, is_maximized, set_skip_taskbar}` que `MockRuntime` n'implémente pas, validé via Vitest (helpers DI) + smoke test @thierry.
+- **8 tests Vitest** dans `src/session-view.dom.test.ts` (env jsdom) : 5 sur `setKeepTaskbarToggle` / `restoreKeepTaskbarFromStorage` / `getKeepTaskbarPreference` (lifecycle ON/OFF + restore + default + preference probe), 3 sur `setMaximizeButtonState` (swap icône + aria-label + cleanup children). Pattern aligné sur les tests `AlwaysOnTop` v0.2.0.
+
 ## [0.2.1] - 2026-05-01
 
 Hotfix sprint pour [#39](https://github.com/thierryvm/SynapseHub/issues/39) — single-instance lock + clean update flow. Adresse les deux régressions de cycle de vie observées sur v0.2.0 :

--- a/index.html
+++ b/index.html
@@ -63,6 +63,11 @@
               <path d="M3 8h10" />
             </svg>
           </button>
+          <button class="win-btn" id="btn-maximize" data-action="maximize" aria-label="Agrandir" title="Agrandir" data-maximized="false">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3.5" y="3.5" width="9" height="9" rx="0.6" />
+            </svg>
+          </button>
           <button class="win-btn" id="btn-close" data-action="close" aria-label="Fermer">
             <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" aria-hidden="true">
               <path d="M3.5 3.5l9 9M12.5 3.5l-9 9" />
@@ -202,6 +207,19 @@
             ></button>
             <p class="setting-help">
               Garde SynapseHub par-dessus toutes les autres fenêtres. Désactivé par défaut pour ne pas bloquer le focus de l'IDE après un click flèche.
+            </p>
+          </div>
+          <div class="setting-row">
+            <span class="setting-label">Garder dans la barre des tâches</span>
+            <button
+              class="toggle"
+              id="btn-toggle-keep-taskbar"
+              type="button"
+              aria-pressed="false"
+              aria-label="Activer ou désactiver l'affichage dans la barre des tâches Windows ou le Dock macOS"
+            ></button>
+            <p class="setting-help">
+              Désactivé par défaut : SynapseHub reste un compagnon tray invisible et le bouton réduire l'envoie dans le tray. Activé : la fenêtre apparaît dans la barre des tâches Windows ou le Dock macOS, et le bouton réduire effectue un minimize OS classique.
             </p>
           </div>
         </section>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,70 @@ fn hide_window(app: AppHandle) {
     }
 }
 
+/// Standard OS-native minimize for the dashboard window. Different from
+/// `hide_window`: this collapses the window to the taskbar (Windows) / Dock
+/// (macOS) / system tray icon (Linux) using the platform's normal minimize
+/// behaviour, instead of fully hiding it. Used by the minimize button when
+/// the user has enabled "Garder dans la barre des tâches" in settings.
+#[tauri::command]
+fn minimize_window<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let win = app
+        .get_webview_window("dashboard")
+        .ok_or_else(|| "dashboard window not found".to_string())?;
+    win.minimize().map_err(|e| e.to_string())
+}
+
+/// Toggles the dashboard between maximized and normal states. Returns the
+/// new state so the frontend can swap the button icon (single square ↔
+/// overlapping squares) without a separate poll. Errors are propagated as
+/// strings so the JS handler can log them.
+#[tauri::command]
+fn toggle_maximize<R: Runtime>(app: AppHandle<R>) -> Result<bool, String> {
+    let win = app
+        .get_webview_window("dashboard")
+        .ok_or_else(|| "dashboard window not found".to_string())?;
+    let was_maximized = win.is_maximized().map_err(|e| e.to_string())?;
+    if was_maximized {
+        win.unmaximize().map_err(|e| e.to_string())?;
+        Ok(false)
+    } else {
+        win.maximize().map_err(|e| e.to_string())?;
+        Ok(true)
+    }
+}
+
+/// Toggles whether the dashboard appears in the OS taskbar (Windows) / Dock
+/// (macOS) / pager (Linux). Default OFF preserves the tray-companion
+/// pattern; ON makes SynapseHub a regular windowed app that shows up in
+/// Alt+Tab and the taskbar.
+///
+/// On macOS we additionally flip the activation policy: `Regular` (Dock
+/// icon visible, app appears in Cmd+Tab) when keep=true, `Accessory` (no
+/// Dock icon, equivalent to skipTaskbar) when keep=false. Without this the
+/// `set_skip_taskbar(false)` call alone has no visible effect on macOS,
+/// because the activation policy set in `setup` already pinned the app to
+/// Accessory.
+#[tauri::command]
+fn set_keep_taskbar<R: Runtime>(app: AppHandle<R>, keep: bool) -> Result<(), String> {
+    let win = app
+        .get_webview_window("dashboard")
+        .ok_or_else(|| "dashboard window not found".to_string())?;
+    win.set_skip_taskbar(!keep).map_err(|e| e.to_string())?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let policy = if keep {
+            tauri::ActivationPolicy::Regular
+        } else {
+            tauri::ActivationPolicy::Accessory
+        };
+        app.set_activation_policy(policy)
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
 /// Toggles the dashboard's `alwaysOnTop` flag at runtime. Driven by the user
 /// toggle in the settings drawer and by the focus action (which temporarily
 /// disables alwaysOnTop so the IDE window can come to the foreground without
@@ -335,6 +399,9 @@ pub fn run() {
             focus_window,
             acknowledge_waiting,
             hide_window,
+            minimize_window,
+            toggle_maximize,
+            set_keep_taskbar,
             set_always_on_top,
             quit_app,
             quit_and_install_update,
@@ -469,6 +536,53 @@ mod tests {
             let args = vec!["synapsehub".to_string(), "--from-shortcut".to_string()];
             let cwd = "/home/thier".to_string();
             handle_second_instance_attempt(app.handle(), &args, &cwd);
+        }
+    }
+
+    // ─── v0.3.0 Vague 1 (#33 + #34) — frame controls + taskbar toggle ───────
+    //
+    // Same Windows-test-binary constraint as the single-instance helpers
+    // above: `tauri::test::mock_app()` trips STATUS_ENTRYPOINT_NOT_FOUND on
+    // Windows. We keep these gated to non-Windows and rely on the CI matrix
+    // (macOS + Linux x64 + Linux ARM64) to exercise them. The happy paths
+    // depend on real `WebviewWindow` operations (`minimize`, `is_maximized`,
+    // `set_skip_taskbar`) which `MockRuntime` does not implement, so we
+    // assert on the err branch only — the mock app has no "dashboard"
+    // window, so each command must surface the canonical not-found message
+    // instead of panicking.
+
+    #[cfg(not(target_os = "windows"))]
+    mod vague_1_window_controls_mock_app {
+        use super::*;
+
+        #[test]
+        fn minimize_window_errors_when_dashboard_window_absent() {
+            let app = tauri::test::mock_app();
+            let err = minimize_window(app.handle().clone()).unwrap_err();
+            assert!(
+                err.contains("dashboard window not found"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn toggle_maximize_errors_when_dashboard_window_absent() {
+            let app = tauri::test::mock_app();
+            let err = toggle_maximize(app.handle().clone()).unwrap_err();
+            assert!(
+                err.contains("dashboard window not found"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn set_keep_taskbar_errors_when_dashboard_window_absent() {
+            let app = tauri::test::mock_app();
+            let err = set_keep_taskbar(app.handle().clone(), true).unwrap_err();
+            assert!(
+                err.contains("dashboard window not found"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -153,6 +153,38 @@ export function buildCloseIcon(): SVGSVGElement {
   return s;
 }
 
+/** Single rounded square — the "maximize" affordance shown when the window
+ * is in its normal (non-maximized) state. Click swaps to {@link buildRestoreIcon}. */
+export function buildMaximizeIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.4",
+    "stroke-linejoin": "round",
+  });
+  svgRect(s, { x: "3.5", y: "3.5", width: "9", height: "9", rx: "0.6" });
+  return s;
+}
+
+/** Two overlapping squares — the "restore" affordance shown when the window
+ * is currently maximized. Matches the Windows convention (back square peeking
+ * out top-right, front square fully drawn bottom-left). */
+export function buildRestoreIcon(): SVGSVGElement {
+  const s = svg("0 0 16 16", {
+    fill: "none",
+    stroke: "currentColor",
+    "stroke-width": "1.4",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  });
+  // Back square — only the top edge and the right edge are visible (the
+  // bottom-left corner is hidden behind the front square).
+  svgPath(s, "M6 3.5h6.5v6.5");
+  // Front square — fully drawn rounded rectangle.
+  svgRect(s, { x: "3.5", y: "6", width: "6.5", height: "6.5", rx: "0.6" });
+  return s;
+}
+
 export function buildBrandGlyph(): SVGSVGElement {
   const s = svg("0 0 32 32", { fill: "none", xmlns: SVG_NS });
   svgCircle(s, 16, 16, 3.2, { fill: "currentColor" });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,11 +9,15 @@ import {
   attachFocusHandler,
   attachUpdateConfirmHandlers,
   getAlwaysOnTopPreference,
+  getKeepTaskbarPreference,
   handleQuitAndInstall,
   notifyUpdateSuccessIfNeeded,
   renderSessionCard,
   restoreAlwaysOnTopFromStorage,
+  restoreKeepTaskbarFromStorage,
   setAlwaysOnTopToggle,
+  setKeepTaskbarToggle,
+  setMaximizeButtonState,
   showUpdateFailedToast,
   sortSessions,
 } from "./session-view";
@@ -47,6 +51,7 @@ const footerDetail = document.getElementById("footer-detail") as HTMLElement;
 const versionLabel = document.getElementById("version-label") as HTMLElement;
 
 const btnMinimize = document.getElementById("btn-minimize") as HTMLButtonElement;
+const btnMaximize = document.getElementById("btn-maximize") as HTMLButtonElement;
 const btnClose = document.getElementById("btn-close") as HTMLButtonElement;
 const btnSettings = document.getElementById("btn-settings") as HTMLButtonElement;
 const btnShowOnboarding = document.getElementById("btn-show-onboarding") as HTMLButtonElement;
@@ -58,6 +63,7 @@ const btnCopyConfig = document.getElementById("btn-copy-config") as HTMLButtonEl
 const configCode = document.getElementById("config-code") as HTMLElement;
 const modalStatus = document.getElementById("modal-status") as HTMLElement;
 const btnToggleAlwaysOnTop = document.getElementById("btn-toggle-always-on-top") as HTMLButtonElement;
+const btnToggleKeepTaskbar = document.getElementById("btn-toggle-keep-taskbar") as HTMLButtonElement;
 
 const updateSummary = document.getElementById("update-summary") as HTMLElement;
 const updateMeta = document.getElementById("update-meta") as HTMLElement;
@@ -226,11 +232,18 @@ function syncAlwaysOnTopButton(): void {
   btnToggleAlwaysOnTop.setAttribute("aria-pressed", String(on));
 }
 
+function syncKeepTaskbarButton(): void {
+  if (!btnToggleKeepTaskbar) return;
+  const keep = getKeepTaskbarPreference();
+  btnToggleKeepTaskbar.setAttribute("aria-pressed", String(keep));
+}
+
 function openDrawer(): void {
   drawer.dataset.open = "true";
   drawer.setAttribute("aria-hidden", "false");
   drawerBackdrop.dataset.open = "true";
   syncAlwaysOnTopButton();
+  syncKeepTaskbarButton();
   void loadConfig();
   void checkForUpdates(false);
 }
@@ -255,6 +268,14 @@ if (btnToggleAlwaysOnTop) {
     const next = btnToggleAlwaysOnTop.getAttribute("aria-pressed") !== "true";
     btnToggleAlwaysOnTop.setAttribute("aria-pressed", String(next));
     setAlwaysOnTopToggle(next, invoke);
+  });
+}
+
+if (btnToggleKeepTaskbar) {
+  btnToggleKeepTaskbar.addEventListener("click", () => {
+    const next = btnToggleKeepTaskbar.getAttribute("aria-pressed") !== "true";
+    btnToggleKeepTaskbar.setAttribute("aria-pressed", String(next));
+    setKeepTaskbarToggle(next, invoke);
   });
 }
 
@@ -557,8 +578,32 @@ btnShowOnboarding.addEventListener("click", openOnboarding);
 
 // ─── Window controls ────────────────────────────────────────────────────────
 
+/**
+ * Minimize behaviour follows the user's "Garder dans la barre des tâches"
+ * preference (#34, Vague 1 v0.3.0):
+ * - Preference OFF (default tray-companion mode): hide_window sends the
+ *   dashboard to the tray entirely.
+ * - Preference ON: minimize_window performs an OS-native minimize so the
+ *   window collapses into the taskbar / Dock instead of disappearing.
+ *
+ * The preference is read live on each click rather than at startup so that
+ * toggling the setting takes effect immediately, without restart.
+ */
 btnMinimize.addEventListener("click", () => {
-  invoke("hide_window").catch(console.error);
+  if (getKeepTaskbarPreference()) {
+    invoke("minimize_window").catch(console.error);
+  } else {
+    invoke("hide_window").catch(console.error);
+  }
+});
+
+btnMaximize.addEventListener("click", async () => {
+  try {
+    const maximized = await invoke<boolean>("toggle_maximize");
+    setMaximizeButtonState(btnMaximize, maximized);
+  } catch (err) {
+    console.error("toggle_maximize failed:", err);
+  }
 });
 
 btnClose.addEventListener("click", () => {
@@ -594,6 +639,39 @@ async function setupFocusListener(): Promise<void> {
   }
 }
 
+/**
+ * Keeps the maximize button icon in sync with the actual window state.
+ * The user can maximize/restore via OS shortcuts (Win+Up, drag-to-edge,
+ * double-click titlebar on macOS) without going through our button, so we
+ * listen on `onResized` and re-query `isMaximized()` after each resize.
+ *
+ * The button starts in "maximize" state (single square SVG already in
+ * `index.html`); we only flip it when the runtime state diverges.
+ */
+async function setupMaximizeListener(): Promise<void> {
+  try {
+    const win = getCurrentWindow();
+    // Initial sync: if the window booted maximized (e.g. user closed the
+    // app while maximized — Tauri can preserve that state), reflect it.
+    try {
+      const initialMax = await win.isMaximized();
+      setMaximizeButtonState(btnMaximize, initialMax);
+    } catch (err) {
+      console.error("Initial isMaximized() probe failed:", err);
+    }
+    await win.onResized(async () => {
+      try {
+        const isMax = await win.isMaximized();
+        setMaximizeButtonState(btnMaximize, isMax);
+      } catch (err) {
+        console.error("onResized isMaximized() probe failed:", err);
+      }
+    });
+  } catch (err) {
+    console.error("Failed to wire onResized listener:", err);
+  }
+}
+
 // ─── Init ───────────────────────────────────────────────────────────────────
 
 async function init(): Promise<void> {
@@ -602,6 +680,16 @@ async function init(): Promise<void> {
   restoreAlwaysOnTopFromStorage(invoke);
   syncAlwaysOnTopButton();
   void setupFocusListener();
+
+  // v0.3.0 Vague 1 (#34): restore "Garder dans la barre des tâches"
+  // preference. Default OFF (matches `tauri.conf.json` skipTaskbar: true);
+  // only invokes Rust when explicitly enabled.
+  restoreKeepTaskbarFromStorage(invoke);
+  syncKeepTaskbarButton();
+
+  // v0.3.0 Vague 1 (#33): keep the maximize button icon in sync with the
+  // OS-side window state, even when the user maximizes via shortcuts.
+  void setupMaximizeListener();
 
   try {
     sessions = await invoke<AgentSession[]>("get_sessions");

--- a/src/session-view.dom.test.ts
+++ b/src/session-view.dom.test.ts
@@ -21,12 +21,17 @@ import {
   ALWAYS_ON_TOP_KEY,
   attachFocusHandler,
   attachUpdateConfirmHandlers,
+  getKeepTaskbarPreference,
   handleQuitAndInstall,
+  KEEP_TASKBAR_KEY,
   LAST_VERSION_KEY,
   notifyUpdateSuccessIfNeeded,
   renderSessionCard,
   restoreAlwaysOnTopFromStorage,
+  restoreKeepTaskbarFromStorage,
   setAlwaysOnTopToggle,
+  setKeepTaskbarToggle,
+  setMaximizeButtonState,
   showToast,
   type AgentSession,
 } from "./session-view";
@@ -352,5 +357,119 @@ describe("Post-update toast notification", () => {
     // Title + message are rendered as text nodes.
     expect(toast?.querySelector(".toast-body")?.textContent).toContain("Test");
     expect(toast?.querySelector(".toast-body")?.textContent).toContain("Body");
+  });
+});
+
+// ─── v0.3.0 Vague 1 (#34) — keep-in-taskbar toggle ───────────────────────────
+
+describe("KeepTaskbar settings toggle", () => {
+  test("toggle ON saves to localStorage and invokes set_keep_taskbar(keep: true)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+
+    setKeepTaskbarToggle(true, invokeMock);
+
+    expect(localStorage.getItem(KEEP_TASKBAR_KEY)).toBe("true");
+    expect(invokeMock).toHaveBeenCalledWith("set_keep_taskbar", { keep: true });
+  });
+
+  test("toggle OFF saves to localStorage and invokes set_keep_taskbar(keep: false)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+    localStorage.setItem(KEEP_TASKBAR_KEY, "true");
+
+    setKeepTaskbarToggle(false, invokeMock);
+
+    expect(localStorage.getItem(KEEP_TASKBAR_KEY)).toBe("false");
+    expect(invokeMock).toHaveBeenCalledWith("set_keep_taskbar", { keep: false });
+  });
+
+  test("on app load, restores localStorage 'true' preference", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+    localStorage.setItem(KEEP_TASKBAR_KEY, "true");
+
+    restoreKeepTaskbarFromStorage(invokeMock);
+
+    expect(invokeMock).toHaveBeenCalledWith("set_keep_taskbar", { keep: true });
+  });
+
+  test("default is keepTaskbar OFF when no localStorage value (no Rust call)", () => {
+    const invokeMock = vi.fn().mockResolvedValue(undefined);
+
+    restoreKeepTaskbarFromStorage(invokeMock);
+
+    // No invoke at all — the Tauri config already has skipTaskbar=true,
+    // so restoring "default" is a no-op and we must not flap the flag.
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  test("getKeepTaskbarPreference returns false by default, true when stored", () => {
+    expect(getKeepTaskbarPreference()).toBe(false);
+
+    localStorage.setItem(KEEP_TASKBAR_KEY, "true");
+    expect(getKeepTaskbarPreference()).toBe(true);
+
+    localStorage.setItem(KEEP_TASKBAR_KEY, "false");
+    expect(getKeepTaskbarPreference()).toBe(false);
+  });
+});
+
+// ─── v0.3.0 Vague 1 (#33) — maximize/restore button state ────────────────────
+
+describe("Maximize button state", () => {
+  function makeButton(): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.id = "btn-maximize";
+    btn.dataset.maximized = "false";
+    document.body.appendChild(btn);
+    return btn;
+  }
+
+  afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  });
+
+  test("setMaximizeButtonState(true) swaps to restore icon + 'Restaurer' label", () => {
+    const btn = makeButton();
+    btn.appendChild(document.createTextNode("placeholder"));
+
+    setMaximizeButtonState(btn, true);
+
+    expect(btn.dataset.maximized).toBe("true");
+    expect(btn.getAttribute("aria-label")).toBe("Restaurer");
+    expect(btn.getAttribute("title")).toBe("Restaurer");
+    // Restore icon is built with both a path (back-square) and a rect (front-square).
+    const svg = btn.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelector("path")).not.toBeNull();
+    expect(svg?.querySelector("rect")).not.toBeNull();
+    // Placeholder text node must be gone.
+    expect(btn.textContent?.includes("placeholder")).toBe(false);
+  });
+
+  test("setMaximizeButtonState(false) swaps to maximize icon + 'Agrandir' label", () => {
+    const btn = makeButton();
+    setMaximizeButtonState(btn, true);
+    expect(btn.dataset.maximized).toBe("true");
+
+    setMaximizeButtonState(btn, false);
+
+    expect(btn.dataset.maximized).toBe("false");
+    expect(btn.getAttribute("aria-label")).toBe("Agrandir");
+    expect(btn.getAttribute("title")).toBe("Agrandir");
+    // Maximize icon = single rect, no extra path.
+    const svg = btn.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelectorAll("rect").length).toBe(1);
+    expect(svg?.querySelectorAll("path").length).toBe(0);
+  });
+
+  test("setMaximizeButtonState toggles back and forth without leftover children", () => {
+    const btn = makeButton();
+    setMaximizeButtonState(btn, true);
+    setMaximizeButtonState(btn, false);
+    setMaximizeButtonState(btn, true);
+
+    // Exactly one SVG child after each call (the previous content was cleared).
+    expect(btn.children.length).toBe(1);
+    expect(btn.children[0].tagName.toLowerCase()).toBe("svg");
   });
 });

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -1,4 +1,12 @@
-import { buildAlertIcon, buildBranchIcon, buildCheckIcon, buildCloseIcon, buildFocusIcon } from "./icons";
+import {
+  buildAlertIcon,
+  buildBranchIcon,
+  buildCheckIcon,
+  buildCloseIcon,
+  buildFocusIcon,
+  buildMaximizeIcon,
+  buildRestoreIcon,
+} from "./icons";
 
 export type AgentStatus =
   | { type: "Running"; since_secs: number }
@@ -428,6 +436,85 @@ export function getAlwaysOnTopPreference(): boolean {
   } catch {
     return false;
   }
+}
+
+// ─── v0.3.0 Vague 1 (#34) — keep-in-taskbar toggle ───────────────────────────
+
+/** Persisted user preference for the "Garder dans la barre des tâches" toggle. */
+export const KEEP_TASKBAR_KEY = "synapsehub_keep_taskbar";
+
+/**
+ * Persists the user preference and pushes it to the Rust side. Mirrors
+ * {@link setAlwaysOnTopToggle} so the two settings rows behave identically.
+ *
+ * Default OFF preserves the tray-companion pattern: SynapseHub stays out of
+ * the taskbar / Dock, minimize sends to tray. When ON, the window appears in
+ * the OS taskbar (Windows) or Dock (macOS), and the minimize button switches
+ * to OS-native minimize (handled in main.ts).
+ */
+export function setKeepTaskbarToggle(keep: boolean, invokeFn: InvokeFn): void {
+  try {
+    localStorage.setItem(KEEP_TASKBAR_KEY, String(keep));
+  } catch {
+    /* localStorage blocked — preference won't persist across launches but the
+       runtime call below still applies for the current session */
+  }
+  void invokeFn("set_keep_taskbar", { keep }).catch((err) =>
+    console.error("set_keep_taskbar failed:", err),
+  );
+}
+
+/**
+ * Reads the persisted preference at app start and pushes it to Rust if (and
+ * only if) the user explicitly enabled it. Default = OFF (matches
+ * `tauri.conf.json` `skipTaskbar: true`); we therefore skip the invoke when
+ * the value is missing or "false" to avoid touching the window state for a
+ * no-op.
+ */
+export function restoreKeepTaskbarFromStorage(invokeFn: InvokeFn): void {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(KEEP_TASKBAR_KEY);
+  } catch {
+    return;
+  }
+  if (stored === "true") {
+    void invokeFn("set_keep_taskbar", { keep: true }).catch((err) =>
+      console.error("set_keep_taskbar failed:", err),
+    );
+  }
+}
+
+/** Reads the current persisted preference. Returns `false` when missing. */
+export function getKeepTaskbarPreference(): boolean {
+  try {
+    return localStorage.getItem(KEEP_TASKBAR_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+// ─── v0.3.0 Vague 1 (#33) — maximize/restore button state ────────────────────
+
+/**
+ * Swaps the maximize button SVG between "maximize" (single rounded square)
+ * and "restore" (two overlapping squares) and updates the accessible label.
+ * Drives both visual feedback and screen reader state.
+ *
+ * Built via `document.createElementNS` (no innerHTML, security hook compliant);
+ * the button's existing children are removed and the new SVG appended.
+ *
+ * The `data-maximized` attribute mirrors the state so CSS can theme the
+ * button differently if needed and tests can assert on it without inspecting
+ * the SVG markup directly.
+ */
+export function setMaximizeButtonState(button: HTMLButtonElement, maximized: boolean): void {
+  while (button.firstChild) button.removeChild(button.firstChild);
+  button.appendChild(maximized ? buildRestoreIcon() : buildMaximizeIcon());
+  const label = maximized ? "Restaurer" : "Agrandir";
+  button.setAttribute("aria-label", label);
+  button.setAttribute("title", label);
+  button.dataset.maximized = String(maximized);
 }
 
 // ─── v0.2.1 — update flow (#39 single-instance + clean update) ──────────────


### PR DESCRIPTION
## Summary

Vague 1 du sprint v0.3.0 — 2 quick wins UX surfacés au smoke test v0.2.0. PR atomique parce que les 2 issues touchent les mêmes fichiers (`index.html`, `src/main.ts`, `src-tauri/src/lib.rs`, `src/session-view.ts`).

- **Closes #33** — Frame: missing maximize/restore button (only minimize + close currently)
- **Closes #34** — Settings: add 'Garder dans la barre des tâches' toggle (Option A)

Handoff parent : `cowork-handoffs/2026-05-02-1515-v0-3-0-sprint-planning.md` (Athenaeum vault).

## Décisions @cowork tranchées avant code

| # | Décision | Verdict |
|---|---|---|
| 1 | btnMinimize comportement quand `keepTaskbar=ON` | **Option β** : vrai `minimize_window` OS-natif. `hide_window` (vers tray) reste pour `keepTaskbar=OFF` (défaut, comportement v0.2.x préservé) |
| 2 | Tests Rust mock_app | Err-only (`dashboard window not found`), happy path validé via Vitest DI + smoke @thierry. Pattern identique à v0.2.1 `single_instance_mock_app` |
| 3 | macOS activation policy | Flip `Regular ↔ Accessory` atomiquement avec `set_skip_taskbar` dans `set_keep_taskbar` (sinon le toggle est un no-op visible sur macOS car policy fixée en `setup`) |

## Livrables code

### Backend Rust (`src-tauri/src/lib.rs`)

3 nouvelles commandes génériques sur `R: Runtime` (testables via `MockRuntime`) :

| Commande | Signature | Rôle |
|---|---|---|
| `toggle_maximize` | `fn(AppHandle<R>) -> Result<bool, String>` | Flip maximisé/normal, retourne nouvel état |
| `set_keep_taskbar` | `fn(AppHandle<R>, keep: bool) -> Result<(), String>` | `set_skip_taskbar(!keep)` + sur macOS `set_activation_policy(Regular/Accessory)` |
| `minimize_window` | `fn(AppHandle<R>) -> Result<(), String>` | Minimize OS-natif (distinct de `hide_window` vers tray) |

Toutes registered dans `invoke_handler!`.

### Frontend TypeScript

- `src/icons.ts` — `buildMaximizeIcon` (carré simple) + `buildRestoreIcon` (double-carré chevauché Windows-style). Zero `innerHTML`, security hook compliant
- `src/session-view.ts` — helpers DI : `KEEP_TASKBAR_KEY`, `setKeepTaskbarToggle`, `restoreKeepTaskbarFromStorage`, `getKeepTaskbarPreference`, `setMaximizeButtonState(button, maximized)`. Pattern aligné sur `setAlwaysOnTopToggle`
- `src/main.ts` — refs `btnMaximize` + `btnToggleKeepTaskbar`, handlers, `setupMaximizeListener` (sync icône via `WebviewWindow.onResized`), `restoreKeepTaskbarFromStorage` dans `init()`
- `src/main.ts` btnMinimize — switch `minimize_window` vs `hide_window` selon `getKeepTaskbarPreference()` (Option β)

### HTML/UI (`index.html`)

- Nouveau `<button id=\"btn-maximize\">` entre minimize et close
- Nouveau setting-row "Garder dans la barre des tâches" sous "Toujours au premier plan" dans le drawer

### CHANGELOG

Entry détaillée dans section `[Unreleased]` (pas de bump version — réservé Phase 7 du sprint, après les 3 vagues mergées).

## Métriques

- **Tests Rust** : 44/44 sur Windows local, attendu **47/47** sur macOS + Linux x64 + Linux ARM64 (3 nouveaux tests `vague_1_window_controls_mock_app::*` cfg-gated non-Windows)
- **Tests Vitest** : **22 → 30** (8 nouveaux : 5 lifecycle keepTaskbar + 3 maximize button state)
- **`cargo clippy --all-targets -- -D warnings`** : clean
- **`cargo fmt --check`** : clean
- **`npm run build`** : 39.28 KB JS (+4.88 KB vs v0.2.1, helpers DI + onResized listener)

## Test plan smoke @thierry obligatoire avant merge

### Scénario A — Maximize button (Windows + macOS)

- [ ] **A1** : Au démarrage, bouton maximize affiche le carré simple (icône "Agrandir"), tooltip "Agrandir"
- [ ] **A2** : Click bouton maximize → fenêtre passe en mode maximisé, icône swap au double-carré chevauché, tooltip devient "Restaurer"
- [ ] **A3** : Re-click bouton (devenu "Restaurer") → fenêtre revient à taille normale, icône re-swap au carré simple
- [ ] **A4** : Maximize via raccourci OS (Win+Up sur Windows, double-click titlebar sur macOS) → icône doit se synchroniser automatiquement (sans click sur le bouton) grâce au `onResized` listener
- [ ] **A5** : Container query header — vérifier que les 4 boutons (settings + minimize + maximize + close) tiennent à `minWidth: 400px` (config Tauri). Si overflow visible, à signaler pour fix CSS

### Scénario B — Keep in taskbar toggle Windows

- [ ] **B1** : Settings drawer ouvert → nouveau toggle "Garder dans la barre des tâches" visible, OFF par défaut
- [ ] **B2** : Avec toggle OFF (défaut) : SynapseHub n'apparaît PAS dans la barre des tâches Windows, click sur "−" envoie dans le tray (comportement v0.2.x préservé)
- [ ] **B3** : Toggle ON : SynapseHub apparaît IMMÉDIATEMENT dans la barre des tâches Windows (pas besoin de redémarrer)
- [ ] **B4** : Avec toggle ON : click sur "−" effectue un MINIMIZE classique Windows (icône reste dans la taskbar, fenêtre collapse au lieu de disparaître)
- [ ] **B5** : Click sur l'icône taskbar restaure la fenêtre
- [ ] **B6** : Re-toggle OFF : fenêtre disparaît IMMÉDIATEMENT de la barre des tâches
- [ ] **B7** : Persistance : restart SynapseHub avec toggle ON → toggle reste ON au boot, fenêtre apparaît bien dans taskbar

### Scénario C — Keep in taskbar toggle macOS (post-merge si pas de machine macOS dispo localement)

- [ ] **C1** : Toggle OFF (défaut) : SynapseHub n'apparaît PAS dans le Dock macOS (`ActivationPolicy::Accessory`)
- [ ] **C2** : Toggle ON : icône Dock apparaît, app accessible via Cmd+Tab (`ActivationPolicy::Regular`)
- [ ] **C3** : Re-toggle OFF : icône Dock disparaît
- [ ] **C4** : Si aucune machine macOS dispo : documenter en checklist post-merge à valider sur la prochaine vraie release v0.3.0 par un user macOS

## Self-review

- [x] Tests Rust + Vitest verts en local
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run build` clean
- [x] Pas de bump version (réservé Phase 7 sprint)
- [x] Pas de scope creep (uniquement #33 + #34 traités, pas d'autre issue v0.3.0 touchée)
- [x] Pas de nouveau token CSS / dependency / refactor module-level
- [x] Sourcery zéro tolérance attendu — patterns identiques à PR #40 v0.2.1 mergée
- [x] Posture sécurité respectée (zero `innerHTML`, helpers via `document.createElementNS` + DOM API)

## Refs

- Handoff Vague 1 : `cowork-handoffs/2026-05-02-1515-v0-3-0-sprint-planning.md` (Athenaeum vault) §4
- Handoff parent v0.2.1 shipped : `cc-handoffs/2026-05-02-1344-v0-2-1-shipped.md` (Athenaeum vault)
- Issue #33 : https://github.com/thierryvm/SynapseHub/issues/33
- Issue #34 : https://github.com/thierryvm/SynapseHub/issues/34

🤖 Generated with [Claude Code](https://claude.com/claude-code)