### PR TITLE
test(watcher): baseline IDE detection coverage (Vague 2a v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **3 tests Rust err-only** dans `src-tauri/src/lib.rs` (module `vague_1_window_controls_mock_app`, gated `#[cfg(not(target_os = "windows"))]` — même contrainte que les helpers single-instance v0.2.1) : `minimize_window_errors_when_dashboard_window_absent`, `toggle_maximize_errors_when_dashboard_window_absent`, `set_keep_taskbar_errors_when_dashboard_window_absent`. Couvrent la branche `dashboard window not found` ; le happy path dépend de `WebviewWindow::{minimize, is_maximized, set_skip_taskbar}` que `MockRuntime` n'implémente pas, validé via Vitest (helpers DI) + smoke test @thierry.
 - **8 tests Vitest** dans `src/session-view.dom.test.ts` (env jsdom) : 5 sur `setKeepTaskbarToggle` / `restoreKeepTaskbarFromStorage` / `getKeepTaskbarPreference` (lifecycle ON/OFF + restore + default + preference probe), 3 sur `setMaximizeButtonState` (swap icône + aria-label + cleanup children). Pattern aligné sur les tests `AlwaysOnTop` v0.2.0.
 
+### Tests (Vague 2a — refs [#43](https://github.com/thierryvm/SynapseHub/issues/43), opens [#45](https://github.com/thierryvm/SynapseHub/issues/45))
+
+Baseline test coverage pour `detect_ide_name` (`src-tauri/src/watcher.rs`). Les patterns `name_lower.contains(...)` pour Codex / Cursor / Windsurf / Aider / Cline / OpenHands existaient déjà mais sans tests dédiés ; ce bloc pin le comportement actuel comme baseline avant tout futur affinement (qui n'arrivera qu'avec data empirique sur les invocations CLI bundled dans Node ou Python).
+
+- **11 nouveaux tests Rust** dans `watcher::tests` :
+  - `detects_openai_codex_desktop_via_windowsapps_path` — Codex desktop OpenAI via Microsoft Store. Pattern OK ; le filtrage `resolve_project_path` (cwd dans WindowsApps = `system_path` rejeté) est tracké séparément en [#45](https://github.com/thierryvm/SynapseHub/issues/45) (v0.4.0 candidate)
+  - `detects_cursor_from_process_name` + `detects_cursor_subprocess` — Cursor.exe + sub-processes Electron `--type=renderer`
+  - `detects_windsurf_from_process_name` — Windsurf.exe (Codeium fork)
+  - `detects_aider_from_process_name_when_packaged` — pour les builds PyInstaller / pip-shim qui produisent un `aider.exe`
+  - `aider_python_module_invocation_currently_unmatched_regression_check` — bookmark régression : `python -m aider` sous `python.exe` n'est PAS matché par le pattern actuel ; le test pin ce comportement pour qu'un futur affinement (post-empirical-diagnostic) soit une flip intentionnelle de None → Some("Aider")
+  - `detects_cline_from_process_name` — pour le cas standalone hypothétique
+  - `cline_vscode_extension_currently_unmatched_regression_check` — bookmark régression : Cline en extension VSCode (host = `code.exe`) tombe sur le fallback "VSCode" actuel ; tracké pour refinement futur
+  - `detects_openhands_from_process_name` — pour les builds standalone PyInstaller
+  - `openhands_docker_host_currently_unmatched_regression_check` — bookmark régression : OpenHands Docker (host = `docker.exe`) hors scope du watcher (introspection `docker ps` requise)
+  - `does_not_misclassify_unrelated_node_processes` — sanity check : npm/Vite/MCP servers Node ne sont pas faux-positifs
+
+Les tests `*_currently_unmatched_regression_check` documentent intentionnellement les limites du pattern matching actuel comme bookmarks pour refinement futur — ils seront flippés positifs dès qu'on aura des cmd lines empiriques d'invocations Aider Python / Cline VSCode-extension / OpenHands non-Docker (cf. [#43](https://github.com/thierryvm/SynapseHub/issues/43) reste ouvert pour ce scope).
+
 ## [0.2.1] - 2026-05-01
 
 Hotfix sprint pour [#39](https://github.com/thierryvm/SynapseHub/issues/39) — single-instance lock + clean update flow. Adresse les deux régressions de cycle de vie observées sur v0.2.0 :

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -697,6 +697,178 @@ mod tests {
         );
     }
 
+    // ─── v0.3.0 Vague 2a (#43) — IDE detection coverage baseline ─────────────
+    //
+    // The 6 IDEs targeted by issue #43 (Codex / Cursor / Aider / Cline /
+    // OpenHands / Windsurf) had bare-minimum `name_lower.contains(...)`
+    // patterns prior to v0.3.0 but no dedicated tests. The block below pins
+    // the *current* behaviour as a regression baseline before the post-pwsh
+    // refinement round adds cmd-line aware patterns for Node-bundled and
+    // Python-bundled invocations. Tests labelled "*_currently_unmatched_*"
+    // are intentional bookmarks documenting where the current matcher falls
+    // short — they will be flipped to positive matches once empirical cmd
+    // lines from @thierry's diagnostic are merged in.
+
+    #[test]
+    fn detects_openai_codex_desktop_via_windowsapps_path() {
+        // OpenAI Codex desktop app is distributed via the Microsoft Store
+        // and installs under `WindowsApps/OpenAI.Codex_<version>/app/Codex.exe`.
+        // ProcessName lowercased is "codex" → caught by the existing
+        // `name_lower.contains("codex")` arm BEFORE the generic VSCode
+        // fallback. The desktop-app project resolution is a separate
+        // concern: `resolve_project_path` rejects WindowsApps cwd as a
+        // system path, so Codex desktop sessions still don't surface
+        // until v0.4.0+ adds lock-file-based desktop hooks (#43 §2).
+        assert_eq!(
+            detect_ide_name(
+                "codex.exe",
+                r#""c:\program files\windowsapps\openai.codex_26.429.2026.0_x64__2p2nqsd0c76g0\app\codex.exe""#
+            ),
+            Some("OpenAI Codex")
+        );
+    }
+
+    #[test]
+    fn detects_cursor_from_process_name() {
+        // Cursor ships as an Electron app with a real `Cursor.exe` host
+        // binary. ProcessName lowercased is "cursor.exe" or "cursor".
+        assert_eq!(detect_ide_name("cursor.exe", "cursor.exe"), Some("Cursor"));
+        assert_eq!(detect_ide_name("cursor", "cursor"), Some("Cursor"));
+    }
+
+    #[test]
+    fn detects_cursor_subprocess() {
+        // Cursor renderer / utility helpers inherit the same process name
+        // and add a `--type=…` Electron flag.
+        assert_eq!(
+            detect_ide_name(
+                "cursor.exe",
+                r#""c:\users\thier\appdata\local\programs\cursor\cursor.exe" --type=renderer"#
+            ),
+            Some("Cursor")
+        );
+    }
+
+    #[test]
+    fn detects_windsurf_from_process_name() {
+        // Windsurf is the Codeium fork of VSCode, also Electron-based.
+        // Distinct ProcessName "windsurf.exe" — not the generic "code.exe".
+        assert_eq!(
+            detect_ide_name("windsurf.exe", "windsurf.exe"),
+            Some("Windsurf")
+        );
+    }
+
+    #[test]
+    fn detects_aider_from_process_name_when_packaged() {
+        // PyInstaller / pip-shim packaging produces a real `aider.exe`
+        // binary on Windows. The pure-pip install path (`python -m aider`)
+        // requires cmd-line matching and is captured below as a regression
+        // bookmark — tracked for refinement once empirical cmd-line lands.
+        assert_eq!(
+            detect_ide_name("aider.exe", "aider --model gpt-4o"),
+            Some("Aider")
+        );
+        assert_eq!(detect_ide_name("aider", "aider"), Some("Aider"));
+    }
+
+    #[test]
+    fn aider_python_module_invocation_currently_unmatched_regression_check() {
+        // `python -m aider` and `python /path/to/aider/__main__.py` run
+        // under `python.exe`. The current `name_lower.contains("aider")`
+        // pattern does NOT match this invocation, so the watcher returns
+        // None and the session does not surface. This test pins today's
+        // behaviour so the post-empirical refinement is an intentional
+        // change (assertion will flip from None to Some("Aider")).
+        assert_eq!(
+            detect_ide_name("python.exe", "python -m aider --model gpt-4o"),
+            None
+        );
+        assert_eq!(
+            detect_ide_name(
+                "python.exe",
+                r#""c:\program files\python313\python.exe" "c:\users\thier\appdata\roaming\python\python313\scripts\aider.py" --model gpt-4o"#
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_cline_from_process_name() {
+        // Hypothetical standalone packaging — captures the current pattern
+        // intent. The realistic VSCode-extension hosting path (`code.exe`
+        // + cline extension dir) is tracked separately as a regression
+        // bookmark below.
+        assert_eq!(detect_ide_name("cline.exe", "cline"), Some("Cline"));
+    }
+
+    #[test]
+    fn cline_vscode_extension_currently_unmatched_regression_check() {
+        // Cline ships as a VSCode extension. The host process is `code.exe`
+        // and `name_lower.contains("cline")` returns false. The dispatcher
+        // routes a bare `code.exe` to "VSCode" instead via the generic
+        // `name.contains("code")` arm. Pinned as a regression bookmark —
+        // post-empirical refinement will add a cmd-line check that lifts
+        // Cline above the VSCode fallback when its extension path appears
+        // in the args.
+        assert_eq!(
+            detect_ide_name(
+                "code.exe",
+                r#""c:\users\thier\appdata\local\programs\microsoft vs code\code.exe" --extension-id rooveterinaryinc.cline"#
+            ),
+            Some("VSCode")
+        );
+    }
+
+    #[test]
+    fn detects_openhands_from_process_name() {
+        // PyInstaller packaging produces a real `openhands.exe`. The
+        // realistic Docker container hosting path is tracked separately
+        // as a regression bookmark — `docker.exe` host is intentionally
+        // unmatched (out of scope for the watcher to introspect Docker).
+        assert_eq!(
+            detect_ide_name("openhands.exe", "openhands"),
+            Some("OpenHands")
+        );
+    }
+
+    #[test]
+    fn openhands_docker_host_currently_unmatched_regression_check() {
+        // OpenHands distributed as Docker container: visible process is
+        // `docker.exe`, not `openhands.exe`. Detecting an OpenHands
+        // container from the host side would require inspecting
+        // `docker ps` output, which is out of scope for the watcher.
+        // Pinned as a regression bookmark — this case is not a candidate
+        // for the post-empirical refinement.
+        assert_eq!(
+            detect_ide_name(
+                "docker.exe",
+                r#""docker" run -p 3000:3000 openhands/openhands-app:latest"#
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn does_not_misclassify_unrelated_node_processes() {
+        // Sanity check: a generic Node tool (npm dev server, Vite, etc.)
+        // that does NOT carry an Anthropic / Codex / agent signature in
+        // its cmd line must return None. This guards against future
+        // pattern additions accidentally over-matching `node.exe`.
+        assert_eq!(detect_ide_name("node.exe", "node"), None);
+        assert_eq!(
+            detect_ide_name("node.exe", "node /usr/local/bin/npm run dev"),
+            None
+        );
+        assert_eq!(
+            detect_ide_name(
+                "node.exe",
+                "node /usr/local/lib/node_modules/vite/bin/vite.js"
+            ),
+            None
+        );
+    }
+
     #[test]
     fn flags_system_locations_as_non_project_paths() {
         assert!(is_system_path("C:\\Program Files\\Codex"));


### PR DESCRIPTION
## Summary

Vague 2a du sprint v0.3.0. **Re-cadrage post-diagnostic empirique** : les patterns `name_lower.contains(...)` pour les 6 IDEs cibles existaient déjà sans tests dédiés. Le diagnostic pwsh côté @thierry a confirmé que :

- **Patterns standalone OK** : Codex desktop (Microsoft Store), Cursor.exe, Windsurf.exe, Aider.exe (PyInstaller), Cline.exe (hypothétique standalone), OpenHands.exe (PyInstaller)
- **Cas non-standalone non couverts** : Aider sous `python -m aider`, Cline en extension VSCode (`code.exe`), OpenHands en Docker (`docker.exe`)
- **Vrai bug observé** ≠ pattern matching : Codex desktop est **détecté** mais **filtré** par `resolve_project_path` (cwd WindowsApps = `system_path` rejeté)

→ **Refs #43 (partial)** — l'issue reste ouverte pour les patterns à ajouter quand @thierry observera réellement les cas non-standalone
→ **Opens #45** — issue v0.4.0-candidate dédiée au scope architectural `resolve_project_path` WindowsApps

## Décisions @cowork tranchées

1. **Option A** validée : pas de patterns spéculatifs sans data empirique (CLAUDE.md "Don't add features beyond what the task requires"). Test coverage baseline + regression bookmarks.
2. **#43 reste ouvert avec scope réduit** — affiner les patterns Aider/Cline/Cursor/Windsurf/OpenHands quand observation empirique live disponible
3. **#45 ouvert séparément** pour scope #2 `resolve_project_path` (v0.4.0)

## Diagnostic empirique @thierry (2 mai 2026)

Commande `Get-CimInstance Win32_Process | Where-Object { $_.Name -match 'codex|cursor|aider|cline|openhands|windsurf|node|python|code' }` a remonté :

| Process | PID | Détecté actuellement ? | Filtre `resolve_project_path` |
|---|---|---|---|
| `Codex.exe` × 5 (WindowsApps OpenAI.Codex) | 21312, 38728, 17428, 14340, 24516 | ✅ pattern `name.contains("codex")` matche | ❌ rejeté (cwd WindowsApps = system_path) |
| `codex.exe` worker `app-server` | 3656 | ✅ matche | ❌ rejeté (idem) |
| `node.exe` × 38 (MCP servers : chrome-devtools, playwright, context7) | divers | n/a (pas IDE) | n/a |
| `python.exe` × 4 (windows-mcp Claude Desktop extension) | 2056, 25628, 1616, 25640 | n/a (pas Aider) | n/a |
| **Aucun Codex CLI standalone** (`@openai/codex`) | n/a | n/a | confusion initiale issue #43 — c'est Codex desktop, pas le CLI |
| **Aucun Cursor / Windsurf / Aider / Cline / OpenHands actif** | n/a | n/a | reportés à observation future |

## Livrables

### Tests Rust (`src-tauri/src/watcher.rs::watcher::tests`)

11 nouveaux tests baseline (27 → 38 watcher tests, 44 → 55 total Rust local Windows) :

**Cas standalone (positifs)** :
- `detects_openai_codex_desktop_via_windowsapps_path`
- `detects_cursor_from_process_name` + `detects_cursor_subprocess`
- `detects_windsurf_from_process_name`
- `detects_aider_from_process_name_when_packaged`
- `detects_cline_from_process_name`
- `detects_openhands_from_process_name`

**Regression bookmarks (intentionally unmatched today)** :
- `aider_python_module_invocation_currently_unmatched_regression_check` — pin behavior actuel pour `python -m aider`
- `cline_vscode_extension_currently_unmatched_regression_check` — pin pour Cline en extension VSCode
- `openhands_docker_host_currently_unmatched_regression_check` — pin pour OpenHands Docker (out of scope watcher)

**Sanity check anti-faux-positif** :
- `does_not_misclassify_unrelated_node_processes` — npm/Vite/MCP servers Node sous `node.exe` ne sont PAS faux-positifs

### CHANGELOG

Entry détaillée dans section `[Unreleased]` "Tests (Vague 2a)" qui documente le re-cadrage et les bookmarks.

## Métriques

- **Tests Rust** : 44 → 55 sur Windows (+11 baseline). Régression-zéro sur les 27 watcher tests + 17 autres existants
- **`cargo clippy --all-targets -- -D warnings`** : clean
- **`cargo fmt --check`** : clean

## Test plan smoke @thierry obligatoire avant merge

**Régression-only** — pas de nouveau pattern ajouté, donc pas de nouvel IDE à valider :

- [ ] **R1** : Lancer `npm run tauri dev` (ou installer un build local NSIS)
- [ ] **R2** : Vérifier qu'au moins 1 session **Claude Code Terminal** active s'affiche toujours dans la dashboard (régression check sur le pattern le plus utilisé)
- [ ] **R3** : Vérifier que **aucune** des sessions Codex.exe / windows-mcp.exe / MCP node servers ne devient un faux positif visible (sanity check sur les nouveaux tests)
- [ ] **R4** : Si tu as une session **Antigravity** active, vérifier qu'elle s'affiche toujours

Si tout vert : merge. Sinon : on diagnostique avant merge.

## Self-review

- [x] Tests Rust + Vitest verts en local (44 → 55 Rust, Vitest non touché)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pas de patterns spéculatifs ajoutés (CLAUDE.md respecté)
- [x] Pas de bump version (réservé Phase 7 sprint, après les 3 vagues)
- [x] Issue #45 ouverte avant cette PR pour tracker scope #2
- [x] PR ne ferme pas #43 (`Refs #43 (partial)` au lieu de `Closes #43`)
- [x] Posture sécurité : aucune nouvelle dépendance, aucun nouveau secret, lecture-only diagnostic empirique

## Refs

- Handoff Vague 2 sprint planning : `Athenaeum/10_Projects/synapsehub/cowork-handoffs/2026-05-02-1515-v0-3-0-sprint-planning.md` §5
- Issue parent : [#43](https://github.com/thierryvm/SynapseHub/issues/43) (reste ouvert)
- Issue scope #2 (architectural) : [#45](https://github.com/thierryvm/SynapseHub/issues/45) (v0.4.0-candidate)
- PR Vague 1 mergée : [#44](https://github.com/thierryvm/SynapseHub/pull/44) (`77dfd6b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)